### PR TITLE
fix(auth): Emit spec-valid authentication_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ permissions:
     name: Write Posts
 ```
 
+For OAuth-based logins (`authorization_code`, `refresh_token`, `device_code`), the authenticate
+response omits `authentication_method` by default: the hosted authorize flow carries no provider
+information, and the spec's `authentication_method` enum has no generic `OAuth` value — only
+provider-specific ones like `GoogleOAuth`. Set `oauth_provider` on a seeded user to have the
+response report a concrete, spec-valid provider. (Password, Magic Auth, and SSO logins already
+report their own method and need no configuration.)
+
+```yaml
+users:
+  - email: alice@acme.com
+    oauth_provider: GoogleOAuth # reported as authentication_method for this user's OAuth logins
+```
+
 ### Machine-to-Machine (M2M) Applications
 
 Seed M2M Connect Applications so a service has a known `client_id` / client secret pair on

--- a/src/e2e.spec.ts
+++ b/src/e2e.spec.ts
@@ -194,7 +194,10 @@ describe('end-to-end login flow (workos.com/docs story)', () => {
     expect(auth.access_token).toBeTruthy();
     expect(auth.refresh_token).toBeTruthy();
     expect(auth.user.email).toBe(email);
-    expect(auth.authentication_method).toBe('OAuth');
+    // The hosted flow carries no provider info and this user has no oauth_provider configured, so
+    // the emulator omits authentication_method rather than inventing one. (The oauth *event* and
+    // session auth_method below still assert the generic 'oauth' — those enums allow it.)
+    expect(auth.authentication_method).toBeUndefined();
 
     // Step 3: webhooks for the new session and the authentication outcome
     const sessionWebhook = await waitForWebhook('session.created', { after: cursor });

--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -41,6 +41,13 @@ export interface WorkOSUser extends Entity {
   locale: string | null;
   password_hash: string | null;
   impersonator: { email: string; reason: string } | null;
+  /**
+   * The OAuth provider this user authenticates with, as a spec-valid
+   * AuthenticateResponse.authentication_method value (e.g. 'GoogleOAuth', 'MicrosoftOAuth').
+   * Reported as the authentication_method for OAuth-based grants; when unset the emulator omits
+   * the field rather than inventing a provider. Internal-only — excluded from the user response.
+   */
+  oauth_provider?: string | null;
 }
 
 export interface WorkOSSession extends Entity {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -94,7 +94,7 @@ export function formatMembership(m: WorkOSOrganizationMembership): Record<string
   return formatEntity(m);
 }
 
-const USER_EXCLUDE = new Set([...INTERNAL_FIELDS, 'impersonator']);
+const USER_EXCLUDE = new Set([...INTERNAL_FIELDS, 'impersonator', 'oauth_provider']);
 
 export function formatUser(user: WorkOSUser): Record<string, unknown> {
   return formatEntity(user, { exclude: USER_EXCLUDE });
@@ -132,6 +132,38 @@ export const AUTH_METHOD_SESSION_VALUES: Record<string, string> = {
   MFA: 'unknown',
   EmailVerification: 'unknown',
 };
+
+/**
+ * Resolve a spec-valid AuthenticateResponse.authentication_method from the emulator's internal
+ * method category, or `undefined` to omit the field when no truthful value is available.
+ *
+ * The response enum is PascalCase and provider-specific: it has no bare 'OAuth', no 'MFA', no
+ * 'EmailVerification', and — unlike the session's auth_method — no 'unknown'. So when the
+ * emulator does not actually know the concrete method, it omits the field (which is nullable in
+ * the SDKs) rather than inventing a provider:
+ *   - 'OAuth' resolves to the user's explicitly configured oauth_provider, else omitted. The
+ *     hosted authorize flow carries no provider information, so there is nothing truthful to
+ *     default to — a fixed provider would just be a fabricated guess.
+ *   - 'MFA' and 'EmailVerification' are verification gates, not methods. The real method is
+ *     whatever initiated the flow; callers pass it via the primary method when known (an MFA
+ *     challenge records the primary factor on the pending-auth token). When it isn't known, the
+ *     field is omitted rather than guessed.
+ * Everything already spec-valid (Password, MagicAuth, SSO, Passkey, GoogleOAuth, …) passes through.
+ */
+export function resolveResponseAuthMethod(
+  method: string,
+  opts?: { oauthProvider?: string | null },
+): string | undefined {
+  switch (method) {
+    case 'OAuth':
+      return opts?.oauthProvider ?? undefined;
+    case 'MFA':
+    case 'EmailVerification':
+      return undefined;
+    default:
+      return method;
+  }
+}
 
 /** authentication.* event names per method, resolved from the spec-generated catalog. */
 export const AUTH_EVENTS: Record<string, { succeeded: WorkOSEventName; failed: WorkOSEventName }> = {

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -89,6 +89,13 @@ export interface WorkOSSeedUser {
   external_id?: string;
   metadata?: Record<string, string>;
   impersonator?: { email: string; reason: string };
+  /**
+   * The OAuth provider this user authenticates with, reported as the authentication_method for
+   * OAuth-based grants (authorization_code, refresh_token, device_code). Must be a spec-valid
+   * value such as 'GoogleOAuth' or 'MicrosoftOAuth'. When omitted the emulator leaves
+   * authentication_method off the response rather than guessing a provider.
+   */
+  oauth_provider?: string;
 }
 
 export interface WorkOSSeedConnection {
@@ -237,6 +244,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: WorkOSSee
         locale: null,
         password_hash: userConfig.password ? hashPassword(userConfig.password) : null,
         impersonator: userConfig.impersonator ?? null,
+        oauth_provider: userConfig.oauth_provider ?? null,
       });
     }
   }

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -125,7 +125,46 @@ describe('Auth routes', () => {
     expect(tokenRes.status).toBe(200);
     const body = await json(tokenRes);
     expect(body.access_token).toBeDefined();
-    expect(body.authentication_method).toBe('OAuth');
+    // authorization_code is an OAuth grant. The hosted flow carries no provider info, so with no
+    // oauth_provider configured on the user the emulator omits authentication_method rather than
+    // emitting the (non-spec) internal 'OAuth' category or inventing a provider.
+    expect(body.authentication_method).toBeUndefined();
+  });
+
+  it('authorization_code grant reports the user configured oauth_provider', async () => {
+    const ws = getWorkOSStore(store);
+    ws.users.insert({
+      object: 'user',
+      email: 'msft@test.com',
+      first_name: null,
+      last_name: null,
+      email_verified: true,
+      profile_picture_url: null,
+      last_sign_in_at: null,
+      external_id: null,
+      metadata: {},
+      locale: null,
+      password_hash: null,
+      impersonator: null,
+      oauth_provider: 'MicrosoftOAuth',
+    });
+
+    const authRes = await app.request(
+      '/user_management/authorize?redirect_uri=http://localhost:3000/callback&response_type=code&login_hint=msft@test.com',
+    );
+    const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!;
+
+    const tokenRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'authorization_code', code }),
+    });
+    expect(tokenRes.status).toBe(200);
+    const body = await json(tokenRes);
+    // A spec-valid provider was explicitly configured, so it flows through verbatim.
+    expect(body.authentication_method).toBe('MicrosoftOAuth');
+    // ...and the internal field never leaks into the user object.
+    expect(body.user.oauth_provider).toBeUndefined();
   });
 
   it('authorize rejects non-localhost redirect_uri', async () => {
@@ -411,12 +450,13 @@ describe('Auth routes', () => {
       code: '123456',
     });
 
-    // Create pending auth
+    // Create pending auth. MFA is a second factor; the pending token records the *primary*
+    // method (here 'Password') so the completed session and response report that, not 'MFA'.
     const pendingToken = 'pending_mfa_token';
     store.setData(`pending_auth:${pendingToken}`, {
       user_id: user.id,
       organization_id: null,
-      auth_method: 'MFA',
+      auth_method: 'Password',
     });
 
     const res = await app.request('/user_management/authenticate', {
@@ -432,7 +472,8 @@ describe('Auth routes', () => {
     expect(res.status).toBe(200);
     const body = await json(res);
     expect(body.access_token).toBeDefined();
-    expect(body.authentication_method).toBe('MFA');
+    // The response reports the primary method the MFA challenge was issued over, not 'MFA'.
+    expect(body.authentication_method).toBe('Password');
   });
 
   it('mfa-totp grant with invalid code returns error', async () => {

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -10,6 +10,7 @@ import {
   assertLocalRedirectUri,
   sealSession,
   AUTH_METHOD_SESSION_VALUES,
+  resolveResponseAuthMethod,
   emitAuthenticationEvent,
   generateCode,
   formatAuthChallenge,
@@ -594,7 +595,13 @@ export function authRoutes(ctx: RouteContext): void {
       organization_id: organizationId,
       access_token: accessToken,
       refresh_token: newRefreshToken.token,
-      authentication_method: authMethod,
+      // The response enum is PascalCase/provider-specific — the internal 'OAuth'/'MFA'/
+      // 'EmailVerification' categories aren't valid here. Resolve to a spec-valid value, or
+      // undefined (key omitted, like impersonator below) when the concrete method is unknown
+      // rather than inventing a provider. Mirrors the session's sessionAuthMethod precedence.
+      authentication_method: resolveResponseAuthMethod(sessionAuthMethod ?? authMethod, {
+        oauthProvider: updatedUser.oauth_provider,
+      }),
       sealed_session: sealedSession,
       impersonator: updatedUser.impersonator ?? undefined,
     });


### PR DESCRIPTION
## Summary

- The `AuthenticateResponse.authentication_method` enum is PascalCase and provider-specific — it has no bare `OAuth`, no `MFA`, and no `EmailVerification`. The emulator was returning its internal method categories verbatim, so those responses failed spec conformance.
- Resolve the internal category to a spec-valid value via a new `resolveResponseAuthMethod` helper: an OAuth grant reports the user's explicitly configured `oauth_provider`, and an MFA/email-verification gate reports the primary method that initiated the flow.
- When no truthful concrete method is known, omit the field (it is nullable in the SDKs) rather than fabricating a provider — the hosted authorize flow carries no provider info, so there is nothing honest to default to.
- Add an internal `oauth_provider` field to seeded users (excluded from the user response) so OAuth logins can report a concrete, spec-valid provider like `GoogleOAuth`.
- Document the `oauth_provider` seeding option in the README so the default omission reads as intended behavior rather than a bug.

Closes https://github.com/workos/emulate/issues/11