### PR TITLE
fix(memberships): Emit directory_managed, roles, and user on organization_membership

### DIFF
--- a/src/e2e.spec.ts
+++ b/src/e2e.spec.ts
@@ -160,6 +160,10 @@ describe('end-to-end login flow (workos.com/docs story)', () => {
     expect(membershipWebhook.data.user_id).toBe(userId);
     expect(membershipWebhook.data.organization_id).toBe(org.id);
     verifySignature(membershipWebhook);
+    expectSpecShape(membershipWebhook);
+    // The event payload stays slim: no REST-only `roles` / `user` embed (matches real WorkOS).
+    expect(membershipWebhook.data).not.toHaveProperty('roles');
+    expect(membershipWebhook.data).not.toHaveProperty('user');
   });
 
   it('completes the hosted authorize → authenticate flow with session and oauth webhooks', async () => {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -90,8 +90,21 @@ export function formatDomain(domain: WorkOSOrganizationDomain): Record<string, u
   return formatEntity(domain);
 }
 
-export function formatMembership(m: WorkOSOrganizationMembership): Record<string, unknown> {
-  return formatEntity(m);
+export function formatMembership(m: WorkOSOrganizationMembership, ws: WorkOSStore): Record<string, unknown> {
+  // Real WorkOS `organization_membership` responses always carry `directory_managed`,
+  // `roles`, and an embedded `user`. The emulator previously omitted all three, which
+  // breaks strict SDK deserializers (e.g. the WorkOS Python SDK's
+  // `OrganizationMembership.from_dict`, whose required-key lookup raises on the first
+  // missing field). The data is already available: `directory_managed` is `false` for
+  // any API-created membership (no directory-sync surface), `roles` is the single
+  // primary role, and the `user` is resolvable from `user_id`.
+  const user = ws.users.get(m.user_id);
+  return {
+    ...formatEntity(m),
+    directory_managed: false,
+    roles: [m.role],
+    user: user ? formatUser(user) : null,
+  };
 }
 
 const USER_EXCLUDE = new Set([...INTERNAL_FIELDS, 'impersonator', 'oauth_provider']);

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -91,19 +91,33 @@ export function formatDomain(domain: WorkOSOrganizationDomain): Record<string, u
 }
 
 export function formatMembership(m: WorkOSOrganizationMembership, ws: WorkOSStore): Record<string, unknown> {
-  // Real WorkOS `organization_membership` responses always carry `directory_managed`,
-  // `roles`, and an embedded `user`. The emulator previously omitted all three, which
-  // breaks strict SDK deserializers (e.g. the WorkOS Python SDK's
+  // Real WorkOS `organization_membership` REST responses always carry `directory_managed`,
+  // `custom_attributes`, `roles`, and an embedded `user`. The emulator previously omitted
+  // them, which breaks strict SDK deserializers (e.g. the WorkOS Python SDK's
   // `OrganizationMembership.from_dict`, whose required-key lookup raises on the first
-  // missing field). The data is already available: `directory_managed` is `false` for
-  // any API-created membership (no directory-sync surface), `roles` is the single
-  // primary role, and the `user` is resolvable from `user_id`.
+  // missing field). `directory_managed` is `false` for any API-created membership (no
+  // directory-sync surface), `custom_attributes` defaults to `{}`, `roles` is the single
+  // primary role, and the `user` is resolved from `user_id` — guaranteed present, since
+  // the create route rejects an unknown user and user deletion cascades its memberships.
   const user = ws.users.get(m.user_id);
   return {
     ...formatEntity(m),
     directory_managed: false,
+    custom_attributes: {},
     roles: [m.role],
     user: user ? formatUser(user) : null,
+  };
+}
+
+// Webhook events carry a slimmer membership than the REST responses: the real WorkOS
+// `organization_membership.*` event payload requires `directory_managed` and
+// `custom_attributes`, but NOT `roles` or an embedded `user` (see EVENT_DATA_REQUIREMENTS).
+// Keep the event shape spec-accurate instead of reusing the REST serializer.
+export function formatMembershipEvent(m: WorkOSOrganizationMembership): Record<string, unknown> {
+  return {
+    ...formatEntity(m),
+    directory_managed: false,
+    custom_attributes: {},
   };
 }
 

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -562,9 +562,9 @@ export const workosPlugin: ServicePlugin = {
       onDelete: (d) => eventBus.emit({ event: EVENTS.organizationDomainDeleted, data: formatDomain(d) }),
     });
     ws.organizationMemberships.setHooks({
-      onInsert: (m) => eventBus.emit({ event: EVENTS.organizationMembershipCreated, data: formatMembership(m) }),
-      onUpdate: (m) => eventBus.emit({ event: EVENTS.organizationMembershipUpdated, data: formatMembership(m) }),
-      onDelete: (m) => eventBus.emit({ event: EVENTS.organizationMembershipDeleted, data: formatMembership(m) }),
+      onInsert: (m) => eventBus.emit({ event: EVENTS.organizationMembershipCreated, data: formatMembership(m, ws) }),
+      onUpdate: (m) => eventBus.emit({ event: EVENTS.organizationMembershipUpdated, data: formatMembership(m, ws) }),
+      onDelete: (m) => eventBus.emit({ event: EVENTS.organizationMembershipDeleted, data: formatMembership(m, ws) }),
     });
     ws.connections.setHooks({
       // The spec has no connection.created/updated — only activation state transitions

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -46,7 +46,7 @@ import {
   expiresIn,
   formatUser,
   formatOrganization,
-  formatMembership,
+  formatMembershipEvent,
   formatConnection,
   formatSession,
   formatInvitation,
@@ -562,9 +562,9 @@ export const workosPlugin: ServicePlugin = {
       onDelete: (d) => eventBus.emit({ event: EVENTS.organizationDomainDeleted, data: formatDomain(d) }),
     });
     ws.organizationMemberships.setHooks({
-      onInsert: (m) => eventBus.emit({ event: EVENTS.organizationMembershipCreated, data: formatMembership(m, ws) }),
-      onUpdate: (m) => eventBus.emit({ event: EVENTS.organizationMembershipUpdated, data: formatMembership(m, ws) }),
-      onDelete: (m) => eventBus.emit({ event: EVENTS.organizationMembershipDeleted, data: formatMembership(m, ws) }),
+      onInsert: (m) => eventBus.emit({ event: EVENTS.organizationMembershipCreated, data: formatMembershipEvent(m) }),
+      onUpdate: (m) => eventBus.emit({ event: EVENTS.organizationMembershipUpdated, data: formatMembershipEvent(m) }),
+      onDelete: (m) => eventBus.emit({ event: EVENTS.organizationMembershipDeleted, data: formatMembershipEvent(m) }),
     });
     ws.connections.setHooks({
       // The spec has no connection.created/updated — only activation state transitions

--- a/src/workos/routes/authorization-resources.ts
+++ b/src/workos/routes/authorization-resources.ts
@@ -90,7 +90,7 @@ export function authorizationResourceRoutes(ctx: RouteContext): void {
     const memberships = ws.organizationMemberships.findBy('organization_id', resource.organization_id);
     return c.json({
       object: 'list',
-      data: memberships.map(formatMembership),
+      data: memberships.map((m) => formatMembership(m, ws)),
       list_metadata: { before: null, after: null },
     });
   });
@@ -122,7 +122,7 @@ export function authorizationResourceRoutes(ctx: RouteContext): void {
     const memberships = ws.organizationMemberships.findBy('organization_id', resource.organization_id);
     return c.json({
       object: 'list',
-      data: memberships.map(formatMembership),
+      data: memberships.map((m) => formatMembership(m, ws)),
       list_metadata: { before: null, after: null },
     });
   });

--- a/src/workos/routes/memberships.spec.ts
+++ b/src/workos/routes/memberships.spec.ts
@@ -56,6 +56,32 @@ describe('Membership routes', () => {
     expect(m.status).toBe('active');
   });
 
+  it('404s when creating a membership for an unknown user', async () => {
+    const org = await createOrg('No User Org');
+    const res = await req('/user_management/organization_memberships', {
+      method: 'POST',
+      body: JSON.stringify({ organization_id: org.id, user_id: 'user_does_not_exist' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('cascades user deletion to memberships (no orphan -> embedded user is never null)', async () => {
+    const org = await createOrg('Cascade Org');
+    const user = await createUser('cascade@test.com');
+    const m = await json(
+      await req('/user_management/organization_memberships', {
+        method: 'POST',
+        body: JSON.stringify({ organization_id: org.id, user_id: user.id }),
+      }),
+    );
+
+    await req(`/user_management/users/${user.id}`, { method: 'DELETE' });
+
+    // Membership is gone, so no read can surface a null embedded user.
+    const got = await req(`/user_management/organization_memberships/${m.id}`);
+    expect(got.status).toBe(404);
+  });
+
   it('rejects duplicate active membership', async () => {
     const org = await createOrg('Dup Org');
     const user = await createUser('dup@test.com');
@@ -125,6 +151,7 @@ describe('Membership routes', () => {
 
     // Fields real WorkOS always returns; required by strict SDK deserializers.
     expect(m.directory_managed).toBe(false);
+    expect(m.custom_attributes).toEqual({});
     expect(m.roles).toEqual([{ slug: 'admin' }]);
     expect(m.user).toMatchObject({ object: 'user', id: user.id, email: 'contract@test.com' });
     // The embedded user must be the full SDK User shape (every key present).

--- a/src/workos/routes/memberships.spec.ts
+++ b/src/workos/routes/memberships.spec.ts
@@ -111,4 +111,55 @@ describe('Membership routes', () => {
     );
     expect(reactivated.status).toBe('active');
   });
+
+  it('serializes directory_managed, roles, and the embedded user (WorkOS SDK contract)', async () => {
+    const org = await createOrg('Contract Org');
+    const user = await createUser('contract@test.com');
+
+    const m = await json(
+      await req('/user_management/organization_memberships', {
+        method: 'POST',
+        body: JSON.stringify({ organization_id: org.id, user_id: user.id, role_slug: 'admin' }),
+      }),
+    );
+
+    // Fields real WorkOS always returns; required by strict SDK deserializers.
+    expect(m.directory_managed).toBe(false);
+    expect(m.roles).toEqual([{ slug: 'admin' }]);
+    expect(m.user).toMatchObject({ object: 'user', id: user.id, email: 'contract@test.com' });
+    // The embedded user must be the full SDK User shape (every key present).
+    for (const k of [
+      'object',
+      'id',
+      'email',
+      'email_verified',
+      'first_name',
+      'last_name',
+      'profile_picture_url',
+      'last_sign_in_at',
+      'created_at',
+      'updated_at',
+    ]) {
+      expect(m.user).toHaveProperty(k);
+    }
+  });
+
+  it('includes the SDK-contract fields on GET and list responses', async () => {
+    const org = await createOrg('GetList Org');
+    const user = await createUser('getlist@test.com');
+    const created = await json(
+      await req('/user_management/organization_memberships', {
+        method: 'POST',
+        body: JSON.stringify({ organization_id: org.id, user_id: user.id }),
+      }),
+    );
+
+    const got = await json(await req(`/user_management/organization_memberships/${created.id}`));
+    expect(got.directory_managed).toBe(false);
+    expect(got.user.id).toBe(user.id);
+
+    const list = await json(await req(`/user_management/organization_memberships?organization_id=${org.id}`));
+    expect(list.data[0].directory_managed).toBe(false);
+    expect(list.data[0].user.id).toBe(user.id);
+  });
 });

--- a/src/workos/routes/memberships.ts
+++ b/src/workos/routes/memberships.ts
@@ -28,6 +28,11 @@ export function membershipRoutes(ctx: RouteContext): void {
     const org = ws.organizations.get(organizationId);
     if (!org) throw notFound('Organization');
 
+    // Real WorkOS 404s an unknown user; validating here also guarantees the embedded
+    // `user` in the response (and every later read) is always resolvable, never null.
+    const user = ws.users.get(userId);
+    if (!user) throw notFound('User');
+
     const existing = ws.organizationMemberships
       .findBy('organization_id', organizationId)
       .find((m) => m.user_id === userId && m.status !== 'inactive');

--- a/src/workos/routes/memberships.ts
+++ b/src/workos/routes/memberships.ts
@@ -47,7 +47,7 @@ export function membershipRoutes(ctx: RouteContext): void {
       metadata: (body.metadata as Record<string, string>) ?? {},
     });
 
-    return c.json(formatMembership(membership), 201);
+    return c.json(formatMembership(membership, ws), 201);
   });
 
   app.get('/user_management/organization_memberships', (c) => {
@@ -67,13 +67,13 @@ export function membershipRoutes(ctx: RouteContext): void {
       },
     });
 
-    return c.json(formatListResponse(result, formatMembership));
+    return c.json(formatListResponse(result, (m) => formatMembership(m, ws)));
   });
 
   app.get('/user_management/organization_memberships/:id', (c) => {
     const m = ws.organizationMemberships.get(c.req.param('id'));
     if (!m) throw notFound('Organization Membership');
-    return c.json(formatMembership(m));
+    return c.json(formatMembership(m, ws));
   });
 
   app.put('/user_management/organization_memberships/:id', async (c) => {
@@ -94,7 +94,7 @@ export function membershipRoutes(ctx: RouteContext): void {
     }
 
     const updated = ws.organizationMemberships.update(m.id, updates);
-    return c.json(formatMembership(updated!));
+    return c.json(formatMembership(updated!, ws));
   });
 
   app.delete('/user_management/organization_memberships/:id', (c) => {
@@ -113,7 +113,7 @@ export function membershipRoutes(ctx: RouteContext): void {
     const updated = ws.organizationMemberships.update(m.id, {
       status: 'inactive',
     });
-    return c.json(formatMembership(updated!));
+    return c.json(formatMembership(updated!, ws));
   });
 
   app.put('/user_management/organization_memberships/:id/reactivate', (c) => {
@@ -125,6 +125,6 @@ export function membershipRoutes(ctx: RouteContext): void {
     const updated = ws.organizationMemberships.update(m.id, {
       status: 'active',
     });
-    return c.json(formatMembership(updated!));
+    return c.json(formatMembership(updated!, ws));
   });
 }


### PR DESCRIPTION
## Summary

- `organization_membership` responses omit three fields that real WorkOS always returns — `directory_managed`, `roles`, and an embedded `user` — so the responses fail spec conformance and break strict, code-generated SDK deserializers.
- Concretely, the WorkOS Python SDK's `OrganizationMembership.from_dict` does a required-key lookup and raises `Unexpected API response while parsing OrganizationMembership: 'directory_managed'` on the emulator's create / get / list responses (`directory_managed` is just the first missing key; `roles` and `user` fail next). The common create-org → create-membership flow is therefore unusable against the emulator even though it works in production.
- `formatMembership` (`src/workos/helpers.ts`) now resolves the user from the store — mirroring the existing `formatOrganization(org, ws)` signature — and includes the missing fields:
  - `directory_managed: false` — an API-created membership is never directory-sync managed
  - `roles: [role]` — the single primary role (`SlimRole`, `{ slug }`)
  - `user` — the full user, via the existing `formatUser`
- All call sites are threaded with the store: the membership routes, the `organization_membership.*` event hooks (`src/workos/index.ts`), and the authorization-resources membership listings.
- `organization_membership` isn't currently covered by `response-shapes.ts`, which is likely why the shape drifted — happy to add it to the conformance codegen (#9) in a follow-up so a regen would catch this class of gap.

## Test plan

- Added unit tests asserting `directory_managed` / `roles` / the full embedded `user` on the create, GET-by-id, and list responses.
- Verified the create response now deserializes cleanly through the WorkOS Python SDK (the original failure above).
- Full suite: 490 tests pass; typecheck, lint, and format clean.

## Open question

The same `formatMembership` feeds the `organization_membership.*` webhook events, so `directory_managed` now lands there too (it was absent before). Two things I'd value your steer on:

- Real membership events also carry `custom_attributes` (not modeled yet) — I can emit it (`{}` / `null`) for full event-shape parity.
- The event schema doesn't require `roles` / `user`; since I reused the serializer they now appear on events. If you'd prefer the event payload stay slim, I'll split a dedicated event serializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
