### PR TITLE
chore(deps): bump @workos/openapi-spec from ^0.6.0 to ^0.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/node": "~22.19.7",
         "@vitest/coverage-v8": "^4.0.18",
-        "@workos/openapi-spec": "^0.6.0",
+        "@workos/openapi-spec": "^0.41.0",
         "husky": "^9.1.7",
         "oxfmt": "^0.54.0",
         "oxlint": "^1.69.0",
@@ -1359,9 +1359,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.0.tgz",
-      "integrity": "sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.51.0.tgz",
+      "integrity": "sha512-XoSkEN28ojqvF1fP8mhOlzHPowpr1/jkvbo3qXKIKXG8RqTiQkLCGTvYdMBjcagEheFFXAsaJKM/GMdoczd4Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1369,19 +1369,20 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.32.0.tgz",
-      "integrity": "sha512-B4CsuuokMc3vgNh9e+eFX8FAbjMTWUVgYtBvPXm0X2pwBs9nO2v+m6ARp7lEpg1P42B6XztIdI08BGMqUAerJQ==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.39.0.tgz",
+      "integrity": "sha512-sACPZX1LUf/GLdZ7xyYV7dgZ73gRzi0TVgNXME5OGKVEHPeNv8z91v2KYhuJso8XJ+E5EVpwBU02UEkrKvSycA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.0",
+        "@redocly/config": "^0.51.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
+        "graphql": "^16.14.1",
         "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -1878,9 +1879,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.22.4.tgz",
-      "integrity": "sha512-tjJvQAkQj2Yuk16tqg/YWlZgjfKsK86nz9ps07SwNRDJFq0zVhfrMZKG2UEkoL8ltP6OkGWTUyF/RfcIiBPOag==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.25.1.tgz",
+      "integrity": "sha512-AAimhzErMB2GazAe8iqo2KudBj4Zo27fX3XRrtOn/EfnXvh1cioPXfd97FLc9F/KnJrkncIrJbN23JhmwMihBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1922,13 +1923,13 @@
       }
     },
     "node_modules/@workos/openapi-spec": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@workos/openapi-spec/-/openapi-spec-0.6.0.tgz",
-      "integrity": "sha512-+nNvkvNsjYYX1r9HRB0ZJgdCYMJCLFXhitiui9vzQrhFwsWWqwl3fJuXss2MOPp6hB8S74pLMqU2hVIYjfoXLw==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@workos/openapi-spec/-/openapi-spec-0.41.0.tgz",
+      "integrity": "sha512-6Ic94jnpf0wHgwigjcdQtV7IQG5P6si8GPoGC88uDMJb2MqgZablQ6KbpzVzP0hwX/ZmHSSBGZgpsA2iUGXzmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.22.4"
+        "@workos/oagen": "^0.25.0"
       }
     },
     "node_modules/ajv": {
@@ -2142,9 +2143,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -2189,6 +2190,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -2290,9 +2301,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -2653,9 +2664,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@types/node": "~22.19.7",
     "@vitest/coverage-v8": "^4.0.18",
-    "@workos/openapi-spec": "^0.6.0",
+    "@workos/openapi-spec": "^0.41.0",
     "husky": "^9.1.7",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",

--- a/src/workos/generated/events.ts
+++ b/src/workos/generated/events.ts
@@ -8,6 +8,14 @@
 export const EVENTS = {
   actionAuthenticationDenied: 'action.authentication.denied',
   actionUserRegistrationDenied: 'action.user_registration.denied',
+  agentRegistrationClaimAttemptCreated: 'agent.registration.claim.attempt.created',
+  agentRegistrationClaimCompleted: 'agent.registration.claim.completed',
+  agentRegistrationCreated: 'agent.registration.created',
+  agentRegistrationCredentialIssued: 'agent.registration.credential.issued',
+  agentRegistrationDeleted: 'agent.registration.deleted',
+  agentRegistrationExpired: 'agent.registration.expired',
+  agentRegistrationOrganizationSwitched: 'agent.registration.organization.switched',
+  agentRegistrationRevoked: 'agent.registration.revoked',
   apiKeyCreated: 'api_key.created',
   apiKeyRevoked: 'api_key.revoked',
   apiKeyUpdated: 'api_key.updated',
@@ -24,6 +32,7 @@ export const EVENTS = {
   authenticationPasswordFailed: 'authentication.password_failed',
   authenticationPasswordSucceeded: 'authentication.password_succeeded',
   authenticationRadarRiskDetected: 'authentication.radar_risk_detected',
+  authenticationReauthenticationSucceeded: 'authentication.reauthentication_succeeded',
   authenticationSsoFailed: 'authentication.sso_failed',
   authenticationSsoStarted: 'authentication.sso_started',
   authenticationSsoSucceeded: 'authentication.sso_succeeded',
@@ -80,8 +89,10 @@ export const EVENTS = {
   permissionDeleted: 'permission.deleted',
   permissionUpdated: 'permission.updated',
   pipesConnectedAccountConnected: 'pipes.connected_account.connected',
+  pipesConnectedAccountConnectionFailed: 'pipes.connected_account.connection_failed',
   pipesConnectedAccountDisconnected: 'pipes.connected_account.disconnected',
   pipesConnectedAccountReauthorizationNeeded: 'pipes.connected_account.reauthorization_needed',
+  radarChallengeCreated: 'radar.challenge_created',
   roleCreated: 'role.created',
   roleDeleted: 'role.deleted',
   roleUpdated: 'role.updated',
@@ -99,6 +110,7 @@ export const EVENTS = {
   vaultDekDecrypted: 'vault.dek.decrypted',
   vaultDekRead: 'vault.dek.read',
   vaultKekCreated: 'vault.kek.created',
+  vaultKekDeleted: 'vault.kek.deleted',
   vaultMetadataRead: 'vault.metadata.read',
   vaultNamesListed: 'vault.names.listed',
   waitlistUserApproved: 'waitlist_user.approved',
@@ -110,6 +122,14 @@ export type WorkOSEventName = (typeof EVENTS)[keyof typeof EVENTS];
 
 /** Event names subscribable via webhook endpoints (CreateWebhookEndpointDto). */
 export const SUBSCRIBABLE_EVENTS: readonly WorkOSEventName[] = [
+  'agent.registration.claim.attempt.created',
+  'agent.registration.claim.completed',
+  'agent.registration.created',
+  'agent.registration.credential.issued',
+  'agent.registration.deleted',
+  'agent.registration.expired',
+  'agent.registration.organization.switched',
+  'agent.registration.revoked',
   'api_key.created',
   'api_key.revoked',
   'api_key.updated',
@@ -124,6 +144,7 @@ export const SUBSCRIBABLE_EVENTS: readonly WorkOSEventName[] = [
   'authentication.password_failed',
   'authentication.password_succeeded',
   'authentication.radar_risk_detected',
+  'authentication.reauthentication_succeeded',
   'authentication.sso_failed',
   'authentication.sso_started',
   'authentication.sso_succeeded',
@@ -178,8 +199,10 @@ export const SUBSCRIBABLE_EVENTS: readonly WorkOSEventName[] = [
   'permission.deleted',
   'permission.updated',
   'pipes.connected_account.connected',
+  'pipes.connected_account.connection_failed',
   'pipes.connected_account.disconnected',
   'pipes.connected_account.reauthorization_needed',
+  'radar.challenge_created',
   'role.created',
   'role.deleted',
   'role.updated',
@@ -195,7 +218,7 @@ export const SUBSCRIBABLE_EVENTS: readonly WorkOSEventName[] = [
 
 /** Payload shape shared by authentication.*_succeeded / *_failed events. */
 export interface AuthenticationEventData {
-  type: 'email_verification' | 'magic_auth' | 'mfa' | 'oauth' | 'passkey' | 'password' | 'sso';
+  type: 'email_verification' | 'magic_auth' | 'mfa' | 'oauth' | 'passkey' | 'password' | 'reauthentication' | 'sso';
   status: 'failed' | 'succeeded';
   ip_address: string | null;
   user_agent: string | null;
@@ -235,6 +258,52 @@ export const EVENT_DATA_REQUIREMENTS: Record<string, { type?: string; status?: s
         'user_agent',
       ],
     },
+    'agent.registration.claim.attempt.created': {
+      required: [
+        'object',
+        'id',
+        'agent_registration_id',
+        'agent_registration_claim_id',
+        'login_hint',
+        'expires_at',
+        'created_at',
+        'updated_at',
+      ],
+    },
+    'agent.registration.claim.completed': {
+      required: [
+        'object',
+        'id',
+        'agent_registration_id',
+        'completed_by_attempt_id',
+        'claimed_by',
+        'completed_at',
+        'created_at',
+        'updated_at',
+      ],
+    },
+    'agent.registration.created': {
+      required: [
+        'object',
+        'id',
+        'agent_identity',
+        'organization_id',
+        'status',
+        'kind',
+        'method',
+        'created_at',
+        'updated_at',
+      ],
+    },
+    'agent.registration.credential.issued': {
+      required: ['object', 'id', 'agent_registration_id', 'detail', 'created_at', 'updated_at'],
+    },
+    'agent.registration.deleted': { required: ['agent_registration_id'] },
+    'agent.registration.expired': { required: ['agent_registration_id'] },
+    'agent.registration.organization.switched': {
+      required: ['agent_registration_id', 'from_organization_id', 'to_organization_id'],
+    },
+    'agent.registration.revoked': { required: ['agent_registration_id'] },
     'api_key.created': {
       required: [
         'object',
@@ -340,6 +409,11 @@ export const EVENT_DATA_REQUIREMENTS: Record<string, { type?: string; status?: s
     },
     'authentication.radar_risk_detected': {
       required: ['auth_method', 'action', 'control', 'blocklist_type', 'ip_address', 'user_agent', 'user_id', 'email'],
+    },
+    'authentication.reauthentication_succeeded': {
+      type: 'reauthentication',
+      status: 'succeeded',
+      required: ['type', 'status', 'ip_address', 'user_agent', 'user_id', 'email'],
     },
     'authentication.sso_failed': {
       type: 'sso',
@@ -709,13 +783,43 @@ export const EVENT_DATA_REQUIREMENTS: Record<string, { type?: string; status?: s
     'password_reset.created': { required: ['object', 'id', 'user_id', 'email', 'expires_at', 'created_at'] },
     'password_reset.succeeded': { required: ['object', 'id', 'user_id', 'email', 'expires_at', 'created_at'] },
     'permission.created': {
-      required: ['object', 'id', 'slug', 'name', 'description', 'system', 'created_at', 'updated_at'],
+      required: [
+        'object',
+        'id',
+        'slug',
+        'name',
+        'description',
+        'system',
+        'resource_type_slug',
+        'created_at',
+        'updated_at',
+      ],
     },
     'permission.deleted': {
-      required: ['object', 'id', 'slug', 'name', 'description', 'system', 'created_at', 'updated_at'],
+      required: [
+        'object',
+        'id',
+        'slug',
+        'name',
+        'description',
+        'system',
+        'resource_type_slug',
+        'created_at',
+        'updated_at',
+      ],
     },
     'permission.updated': {
-      required: ['object', 'id', 'slug', 'name', 'description', 'system', 'created_at', 'updated_at'],
+      required: [
+        'object',
+        'id',
+        'slug',
+        'name',
+        'description',
+        'system',
+        'resource_type_slug',
+        'created_at',
+        'updated_at',
+      ],
     },
     'pipes.connected_account.connected': {
       required: [
@@ -729,6 +833,20 @@ export const EVENT_DATA_REQUIREMENTS: Record<string, { type?: string; status?: s
         'state',
         'created_at',
         'updated_at',
+      ],
+    },
+    'pipes.connected_account.connection_failed': {
+      required: [
+        'object',
+        'data_integration_id',
+        'provider_slug',
+        'user_id',
+        'organization_id',
+        'error_code',
+        'error_reason',
+        'provider_error',
+        'provider_error_description',
+        'created_at',
       ],
     },
     'pipes.connected_account.disconnected': {
@@ -759,6 +877,7 @@ export const EVENT_DATA_REQUIREMENTS: Record<string, { type?: string; status?: s
         'updated_at',
       ],
     },
+    'radar.challenge_created': { type: 'email', required: ['type', 'radar_challenge_id', 'user_id', 'email'] },
     'role.created': { required: ['object', 'slug', 'resource_type_slug', 'created_at', 'updated_at'] },
     'role.deleted': { required: ['object', 'slug', 'resource_type_slug', 'created_at', 'updated_at'] },
     'role.updated': { required: ['object', 'slug', 'resource_type_slug', 'created_at', 'updated_at'] },
@@ -846,6 +965,7 @@ export const EVENT_DATA_REQUIREMENTS: Record<string, { type?: string; status?: s
     'vault.dek.decrypted': { required: ['actor_id', 'actor_source', 'actor_name', 'key_id'] },
     'vault.dek.read': { required: ['actor_id', 'actor_source', 'actor_name', 'key_ids', 'key_context'] },
     'vault.kek.created': { required: ['actor_id', 'actor_source', 'actor_name', 'key_name', 'key_id'] },
+    'vault.kek.deleted': { required: ['actor_id', 'actor_source', 'actor_name', 'key_name', 'key_id'] },
     'vault.metadata.read': { required: ['actor_id', 'actor_source', 'actor_name', 'kv_name'] },
     'vault.names.listed': { required: ['actor_id', 'actor_source', 'actor_name'] },
     'waitlist_user.approved': {

--- a/src/workos/generated/response-shapes.ts
+++ b/src/workos/generated/response-shapes.ts
@@ -22,13 +22,13 @@ export const RESPONSE_SHAPE_REQUIREMENTS: Record<string, ResponseShapeRequiremen
   connection: {
     schema: 'Connection',
     properties: [
+      'callback_endpoint',
       'connection_type',
       'created_at',
       'domains',
       'id',
       'name',
       'object',
-      'options',
       'organization_id',
       'state',
       'status',


### PR DESCRIPTION
## Summary

- The pinned spec had drifted 35 minor versions behind the published SDKs. Most concretely: 0.6.0's `UserlandUserOrganizationMembership` schema has **no `roles` property**, while the oagen-generated SDKs (e.g. workos-python's `OrganizationMembership.from_dict`) require it via a hard key lookup — so #15 had to emit a field the repo's own source-of-truth spec didn't define.
- 0.41.0 marks `roles` **required** on the membership schema, bringing the pin back in line with what SDK deserializers actually enforce. This also unblocks adding `organization_membership` to the response-shapes conformance codegen (#9) without the conformance test flagging `roles` as an unknown property.
- Regenerated the spec-derived code (`npm run gen:events` + `npm run gen:shapes`):
  - **events.ts** — 11 new event names in the catalog and subscribable list, with payload requirements: `agent.registration.*` (8 events), `authentication.reauthentication_succeeded`, `pipes.connected_account.connection_failed`, `radar.challenge_created`, `vault.kek.deleted`. Catalog is now 92 subscribable events / 110 payload schemas.
  - **response-shapes.ts** — the `Connection` shape gains `callback_endpoint` and drops `options` (neither is in the spec's required list, so no serializer change is needed).
- No hand-written code changes required — the runtime OAuth/token-endpoint behavior is hand-authored by design and unaffected.

## Test plan

- Full suite: 488 tests pass; typecheck, build, lint, and fmt clean (everything CI runs).
- Verified the new spec's membership `required` list now matches the workos-python deserializer (`object`, `id`, `user_id`, `organization_id`, `status`, `directory_managed`, `created_at`, `updated_at`, `role`, `roles`, `user`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)