### PR TITLE
build: publish a self-contained single-file ESM bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Install
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           cache: npm
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
 
       - name: Install
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Install
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
           cache: npm
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
 
       - name: Install
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -700,3 +700,7 @@ The WorkOS Emulator is designed for testing and development environments. When u
 - **Use environment variables**: Store sensitive configuration (API keys, secrets) in environment variables.
 - **Regular updates**: Keep the emulator updated to get security fixes and improvements.
 - **Network isolation**: Run the emulator in an isolated network environment when possible.
+
+## Development
+
+Building from source requires [Bun](https://bun.sh) in addition to Node.js: `npm run build` compiles with `tsc`, then uses `bun build` to emit the self-contained `dist/bundle.js`. If `npm run build` fails with `bun: command not found`, install Bun first.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "./workos": {
       "import": "./dist/workos/index.js",
       "types": "./dist/workos/index.d.ts"
-    }
+    },
+    "./bundle": "./dist/bundle.js"
   },
   "dependencies": {
     "@hono/node-server": "^1",
@@ -63,7 +64,8 @@
     "clean": "rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "tsc",
-    "postbuild": "chmod +x ./dist/cli.js",
+    "postbuild": "chmod +x ./dist/cli.js && npm run build:bundle",
+    "build:bundle": "bun build --target=bun --format=esm src/index.ts --outfile dist/bundle.js",
     "start": "node ./dist/cli.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
       "import": "./dist/workos/index.js",
       "types": "./dist/workos/index.d.ts"
     },
-    "./bundle": "./dist/bundle.js"
+    "./bundle": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/bundle.js"
+    }
   },
   "dependencies": {
     "@hono/node-server": "^1",


### PR DESCRIPTION
## Summary

- Adds a `build:bundle` step that bundles `src/index.ts` into `dist/bundle.js` via `bun build --target=bun --format=esm`, inlining every npm dependency and leaving only `node:` builtins external.
- Wires the bundle into `postbuild`, so `npm run build` emits it alongside the tsc output; it ships in the tarball through the existing `dist` files entry plus a new `./bundle` exports subpath.
- Motivation: the WorkOS CLI (a Bun-compiled standalone binary) can download the tarball at runtime and `import()` the bundle directly, with no node_modules needed beside it — while types keep coming from the package's main export as a build-time dependency.
- Installs Bun in the CI and release workflows so the build step can produce the bundle before pack/publish.
