### PR TITLE
fix(auth): scope AuthKit sessions to an organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,41 @@ Codes that WorkOS would deliver by email are delivered to you in the webhook pay
 
 Webhooks are signed exactly like production WorkOS: `WorkOS-Signature: t=<timestamp>,v1=<hmac>` where the HMAC-SHA256 is computed over `"{timestamp}.{body}"` with the endpoint's secret. The official SDKs' `webhooks.constructEvent` verifies them unchanged.
 
+### Organization-scoped sessions
+
+Every fresh login resolves an organization the way production does, so tokens carry the claims your authorization code reads:
+
+- **One active membership** — selected implicitly. The response returns `organization_id` and the access token carries `org_id`, `role`, `roles`, and `permissions`.
+- **No memberships** — `organization_id` is `null` and the token carries no `org_id`. Nothing is invented.
+- **Several active memberships** — a `403` asking the client to choose, exactly as WorkOS does:
+
+```json
+{
+  "code": "organization_selection_required",
+  "message": "The user must choose an organization to finish their authentication.",
+  "pending_authentication_token": "pending_...",
+  "organizations": [
+    { "id": "org_...", "name": "Alpha Corp" },
+    { "id": "org_...", "name": "Beta Corp" }
+  ],
+  "user": { "object": "user", "id": "user_...", "email": "member@example.com" }
+}
+```
+
+Finish the sign-in by exchanging that token for a session scoped to the chosen organization — the emulator rejects an organization the user is not an active member of with `organization_membership_not_found`:
+
+```bash
+curl -X POST http://localhost:4100/user_management/authenticate \
+  -H "Content-Type: application/json" \
+  -d '{"grant_type":"urn:workos:oauth:grant-type:organization-selection","pending_authentication_token":"pending_...","organization_id":"org_..."}'
+```
+
+Only `active` memberships count — an unaccepted invitation or a deactivated member is never selected. Passing `invitation_token` to the `authorization_code`, `password`, or Magic Auth grants accepts the invitation as part of the login, joining the user to the invited organization and scoping the session to it, so there is no selection step; a token that is unknown, expired, or already used is rejected with `invitation_invalid`, and one addressed to somebody else with `invitation_cannot_be_used_for_email`. Once a session exists, only an explicit `organization_id` on a refresh (`switchToOrganization`) moves it between organizations.
+
+### Refresh tokens always rotate
+
+The emulator issues a new refresh token on every refresh and invalidates the one you presented, so replaying it returns `invalid_grant`. WorkOS documents that refresh tokens _may_ be rotated after use, so production is free to hand back the same token and leave it valid. The emulator always takes the stricter path: a client that forgets to store the newly returned `refresh_token` fails locally instead of in production.
+
 ### Emitted events
 
 Authentication events carry the spec payload `{ type, status, user_id, email, ip_address, user_agent }` (plus `error` on failures and `sso` details on SSO events).

--- a/src/core/jwt.ts
+++ b/src/core/jwt.ts
@@ -5,6 +5,13 @@ export interface JWTPayload {
   sid?: string;
   org_id?: string;
   role?: string;
+  /**
+   * Every role the membership grants. Production emits `roles` alongside the singular
+   * `role`, and the WorkOS SDKs read it; a token carrying only `role` passes locally and
+   * loses the claim in production. The emulator models one role per membership, matching
+   * what the `organization_membership` serializer already does.
+   */
+  roles?: string[];
   permissions?: string[];
   /**
    * OAuth scopes granted to an M2M (client_credentials) token: space-delimited,

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -363,6 +363,51 @@ export function formatInvitation(inv: WorkOSInvitation): Record<string, unknown>
   return formatEntity(inv);
 }
 
+/**
+ * Mark an invitation accepted and join its recipient to the organization it names, returning that
+ * organization's id (null if the invitation names none). Shared by the invitations REST route and
+ * the authenticate grants that accept an `invitation_token` so the two cannot drift; validating
+ * the invitation stays with each caller, which report a bad one under different spec error codes.
+ *
+ * An existing membership is reused rather than duplicated, and a deactivated one is reactivated —
+ * a fresh invitation is how a removed member rejoins.
+ */
+export function acceptInvitation(
+  inv: WorkOSInvitation,
+  user: WorkOSUser | undefined,
+  ws: WorkOSStore,
+  eventBus: EventBus | undefined,
+): string | null {
+  ws.invitations.update(inv.id, { state: 'accepted' });
+  eventBus?.emit({ event: EVENTS.invitationAccepted, data: formatInvitation(ws.invitations.get(inv.id)!) });
+
+  if (!inv.organization_id) return null;
+
+  // The REST route resolves the recipient by email and tolerates an invitation for someone who
+  // has not signed up yet: the invitation is still accepted, there is just nobody to enroll.
+  if (user) {
+    const roleSlug = inv.role_slug ?? 'member';
+    const existing = ws.organizationMemberships
+      .findBy('organization_id', inv.organization_id)
+      .find((m) => m.user_id === user.id);
+    if (!existing) {
+      ws.organizationMemberships.insert({
+        object: 'organization_membership',
+        organization_id: inv.organization_id,
+        user_id: user.id,
+        role: { slug: roleSlug },
+        status: 'active',
+        external_id: null,
+        metadata: {},
+      });
+    } else if (existing.status !== 'active') {
+      ws.organizationMemberships.update(existing.id, { status: 'active', role: { slug: roleSlug } });
+    }
+  }
+
+  return inv.organization_id;
+}
+
 export function formatRedirectUri(r: WorkOSRedirectUri): Record<string, unknown> {
   return formatEntity(r);
 }

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -960,6 +960,92 @@ describe('Auth routes', () => {
     expect((await readInvitation(invitation.token)).state).toBe('accepted');
   });
 
+  it('reports the same error when a deferred invitation dies mid-challenge', async () => {
+    const created = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'mfa-revoked@test.com', password: 'pw' }),
+    });
+    const user = await json(created);
+    const org = createOrg('Vanishing Corp');
+    const invitation = await invite('mfa-revoked@test.com', org.id);
+
+    const ws = getWorkOSStore(store);
+    ws.authFactors.insert({
+      object: 'authentication_factor',
+      user_id: user.id,
+      type: 'totp',
+      totp: { issuer: 'Test', user: user.email, uri: 'otpauth://...' },
+    });
+
+    const passwordRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'password',
+        email: 'mfa-revoked@test.com',
+        password: 'pw',
+        invitation_token: invitation.token,
+      }),
+    });
+    const challengeBody = await json(passwordRes);
+    const challengeCode = ws.authChallenges.get(challengeBody.authentication_challenge.id)!.code;
+
+    // The invitation is withdrawn while the user is still entering their code.
+    await req(`/user_management/invitations/${invitation.id}/revoke`, { method: 'POST' });
+
+    const completeMfa = () =>
+      app.request('/user_management/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'urn:workos:oauth:grant-type:mfa-totp',
+          code: challengeCode,
+          pending_authentication_token: challengeBody.pending_authentication_token,
+          authentication_challenge_id: challengeBody.authentication_challenge.id,
+        }),
+      });
+
+    const first = await completeMfa();
+    expect(first.status).toBe(400);
+    expect((await json(first)).code).toBe('invitation_invalid');
+
+    // The challenge and pending token are revalidated before they are consumed, so a retry reports
+    // the same cause rather than decaying into invalid_pending_authentication_token.
+    const second = await completeMfa();
+    expect(second.status).toBe(400);
+    expect((await json(second)).code).toBe('invitation_invalid');
+
+    expect(ws.sessions.findBy('user_id', user.id)).toHaveLength(0);
+  });
+
+  it('defers an organization-less invitation until selection completes', async () => {
+    const user = await createUser('org-less-invite@test.com');
+    joinOrg(user.id, 'Alpha Existing');
+    const beta = joinOrg(user.id, 'Beta Existing');
+    // An invitation naming no organization cannot settle the choice for a multi-org user.
+    const invitation = await invite('org-less-invite@test.com', null);
+
+    const res = await signInWithMagicAuth('org-less-invite@test.com', invitation.token);
+    expect(res.status).toBe(403);
+    const body = await json(res);
+    expect(body.code).toBe('organization_selection_required');
+    // Not spent on a response that issued no session.
+    expect((await readInvitation(invitation.token)).state).toBe('pending');
+
+    const selected = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:organization-selection',
+        pending_authentication_token: body.pending_authentication_token,
+        organization_id: beta.id,
+      }),
+    });
+    expect(selected.status).toBe(200);
+    expect((await json(selected)).organization_id).toBe(beta.id);
+    expect((await readInvitation(invitation.token)).state).toBe('accepted');
+  });
+
   // --- MFA TOTP grant tests ---
 
   it('mfa-totp grant with valid code succeeds', async () => {

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -46,16 +46,34 @@ describe('Auth routes', () => {
     });
   }
 
-  /** Create an organization and join `userId` to it, defaulting to an active membership. */
-  function joinOrg(userId: string, name: string, opts?: { status?: 'active' | 'inactive' | 'pending'; role?: string }) {
-    const ws = getWorkOSStore(store);
-    const org = ws.organizations.insert({
+  function createOrg(name: string) {
+    return getWorkOSStore(store).organizations.insert({
       object: 'organization',
       name,
       external_id: null,
       metadata: {},
       stripe_customer_id: null,
     });
+  }
+
+  /** Invite `email` to `orgId`, returning the invitation including the token a client would use. */
+  async function invite(email: string, orgId: string | null, roleSlug?: string) {
+    const res = await req('/user_management/invitations', {
+      method: 'POST',
+      body: JSON.stringify({ email, organization_id: orgId, role_slug: roleSlug }),
+    });
+    return json(res);
+  }
+
+  const readInvitation = async (token: string) => json(await req(`/user_management/invitations/by_token/${token}`));
+
+  const membershipsIn = async (orgId: string) =>
+    (await json(await req(`/user_management/organization_memberships?organization_id=${orgId}`))).data;
+
+  /** Create an organization and join `userId` to it, defaulting to an active membership. */
+  function joinOrg(userId: string, name: string, opts?: { status?: 'active' | 'inactive' | 'pending'; role?: string }) {
+    const ws = getWorkOSStore(store);
+    const org = createOrg(name);
     ws.organizationMemberships.insert({
       object: 'organization_membership',
       organization_id: org.id,
@@ -74,7 +92,7 @@ describe('Auth routes', () => {
   }
 
   /** Mint a magic auth code for `email` and exchange it, as a client signing in would. */
-  async function signInWithMagicAuth(email: string) {
+  async function signInWithMagicAuth(email: string, invitationToken?: string) {
     const magicRes = await req('/user_management/magic_auth', {
       method: 'POST',
       body: JSON.stringify({ email }),
@@ -87,6 +105,7 @@ describe('Auth routes', () => {
         grant_type: 'urn:workos:oauth:grant-type:magic-auth:code',
         code,
         email,
+        invitation_token: invitationToken,
       }),
     });
   }
@@ -499,13 +518,13 @@ describe('Auth routes', () => {
     setPending();
     const foreignRes = await select(foreignOrg.id);
     expect(foreignRes.status).toBe(400);
-    expect((await json(foreignRes)).code).toBe('invalid_organization_id');
+    expect((await json(foreignRes)).code).toBe('organization_membership_not_found');
 
     // A rejected selection must not consume the pending token: the client retries with another
     // organization. An unaccepted invitation is not one it can pick.
     const pendingRes = await select(invitedOrg.id);
     expect(pendingRes.status).toBe(400);
-    expect((await json(pendingRes)).code).toBe('invalid_organization_id');
+    expect((await json(pendingRes)).code).toBe('organization_membership_not_found');
   });
 
   // --- Organization resolution on fresh logins ---
@@ -751,6 +770,194 @@ describe('Auth routes', () => {
       }),
     });
     expect((await json(switched)).organization_id).toBe(org.id);
+  });
+
+  // --- invitation_token ---
+
+  it('accepts an invitation_token, joining the org and scoping the session', async () => {
+    await createUser('invited@test.com');
+    const org = createOrg('Invited Corp');
+    const invitation = await invite('invited@test.com', org.id, 'admin');
+
+    const magicRes = await req('/user_management/magic_auth', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'invited@test.com' }),
+    });
+    const { code } = await json(magicRes);
+
+    const res = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:magic-auth:code',
+        code,
+        email: 'invited@test.com',
+        invitation_token: invitation.token,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.organization_id).toBe(org.id);
+
+    const claims = decodeJwt(body.access_token);
+    expect(claims.org_id).toBe(org.id);
+    // The invitation's role_slug becomes the membership role, so the token carries it.
+    expect(claims.role).toBe('admin');
+    expect(claims.roles).toEqual(['admin']);
+
+    expect((await readInvitation(invitation.token)).state).toBe('accepted');
+    const memberships = await membershipsIn(org.id);
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].status).toBe('active');
+  });
+
+  it('lets an invitation_token settle the organization for a multi-org user', async () => {
+    const user = await createUser('invited-multi@test.com');
+    joinOrg(user.id, 'Existing One');
+    joinOrg(user.id, 'Existing Two');
+    const invitedOrg = createOrg('Third Corp');
+    const invitation = await invite('invited-multi@test.com', invitedOrg.id);
+
+    // Without the invitation this user would get organization_selection_required; the invitation
+    // names an organization, so there is nothing left to choose.
+    const res = await signInWithMagicAuth('invited-multi@test.com', invitation.token);
+    expect(res.status).toBe(200);
+    expect((await json(res)).organization_id).toBe(invitedOrg.id);
+  });
+
+  it('reactivates a deactivated membership on a fresh invitation', async () => {
+    const user = await createUser('returning@test.com');
+    const org = joinOrg(user.id, 'Boomerang Corp', { status: 'inactive' });
+    const invitation = await invite('returning@test.com', org.id, 'admin');
+
+    const res = await signInWithMagicAuth('returning@test.com', invitation.token);
+    expect(res.status).toBe(200);
+    expect((await json(res)).organization_id).toBe(org.id);
+
+    // Reused, not duplicated.
+    const memberships = await membershipsIn(org.id);
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].status).toBe('active');
+    expect(memberships[0].role.slug).toBe('admin');
+  });
+
+  it('rejects an invitation issued for a different email', async () => {
+    await createUser('recipient@test.com');
+    await createUser('interloper@test.com');
+    const org = createOrg('Not Yours Corp');
+    const invitation = await invite('recipient@test.com', org.id);
+
+    const res = await signInWithMagicAuth('interloper@test.com', invitation.token);
+    expect(res.status).toBe(400);
+    expect((await json(res)).code).toBe('invitation_cannot_be_used_for_email');
+    expect((await readInvitation(invitation.token)).state).toBe('pending');
+    expect(await membershipsIn(org.id)).toHaveLength(0);
+  });
+
+  it('rejects a revoked or unknown invitation without consuming the one-time code', async () => {
+    await createUser('revoked@test.com');
+    const org = createOrg('Revoked Corp');
+    const invitation = await invite('revoked@test.com', org.id);
+    await req(`/user_management/invitations/${invitation.id}/revoke`, { method: 'POST' });
+
+    const magicRes = await req('/user_management/magic_auth', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'revoked@test.com' }),
+    });
+    const { code } = await json(magicRes);
+
+    const exchange = (invitationToken?: string) =>
+      app.request('/user_management/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'urn:workos:oauth:grant-type:magic-auth:code',
+          code,
+          email: 'revoked@test.com',
+          invitation_token: invitationToken,
+        }),
+      });
+
+    const revokedRes = await exchange(invitation.token);
+    expect(revokedRes.status).toBe(400);
+    expect((await json(revokedRes)).code).toBe('invitation_invalid');
+
+    const unknownRes = await exchange('inv_tok_does_not_exist');
+    expect(unknownRes.status).toBe(400);
+    expect((await json(unknownRes)).code).toBe('invitation_invalid');
+
+    // The invitation is checked before the grant runs, so the magic auth code survives both
+    // rejections and the user can still sign in.
+    const retry = await exchange();
+    expect(retry.status).toBe(200);
+    expect((await json(retry)).organization_id).toBeNull();
+  });
+
+  it('ignores invitation_token on a grant that does not accept one', async () => {
+    await createUser('refresh-invite@test.com');
+    const org = createOrg('Ignored Corp');
+    const invitation = await invite('refresh-invite@test.com', org.id);
+
+    const signIn = await signInWithMagicAuth('refresh-invite@test.com');
+    const { refresh_token } = await json(signIn);
+
+    const refreshed = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'refresh_token', refresh_token, invitation_token: invitation.token }),
+    });
+    expect(refreshed.status).toBe(200);
+    expect((await json(refreshed)).organization_id).toBeNull();
+    // refresh_token has no invitation_token in its schema, so production would never accept it.
+    expect((await readInvitation(invitation.token)).state).toBe('pending');
+  });
+
+  it('holds an invitation until the second factor clears', async () => {
+    const created = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'mfa-invite@test.com', password: 'pw' }),
+    });
+    const user = await json(created);
+    const org = createOrg('Second Factor Corp');
+    const invitation = await invite('mfa-invite@test.com', org.id);
+
+    const ws = getWorkOSStore(store);
+    ws.authFactors.insert({
+      object: 'authentication_factor',
+      user_id: user.id,
+      type: 'totp',
+      totp: { issuer: 'Test', user: user.email, uri: 'otpauth://...' },
+    });
+
+    const passwordRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'password',
+        email: 'mfa-invite@test.com',
+        password: 'pw',
+        invitation_token: invitation.token,
+      }),
+    });
+    expect(passwordRes.status).toBe(403);
+    const challengeBody = await json(passwordRes);
+    expect(challengeBody.code).toBe('mfa_challenge');
+    // Nothing is accepted while the login is still unproven.
+    expect((await readInvitation(invitation.token)).state).toBe('pending');
+
+    const mfaRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:mfa-totp',
+        code: ws.authChallenges.get(challengeBody.authentication_challenge.id)!.code,
+        pending_authentication_token: challengeBody.pending_authentication_token,
+        authentication_challenge_id: challengeBody.authentication_challenge.id,
+      }),
+    });
+    expect(mfaRes.status).toBe(200);
+    expect((await json(mfaRes)).organization_id).toBe(org.id);
+    expect((await readInvitation(invitation.token)).state).toBe('accepted');
   });
 
   // --- MFA TOTP grant tests ---

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -46,6 +46,51 @@ describe('Auth routes', () => {
     });
   }
 
+  /** Create an organization and join `userId` to it, defaulting to an active membership. */
+  function joinOrg(userId: string, name: string, opts?: { status?: 'active' | 'inactive' | 'pending'; role?: string }) {
+    const ws = getWorkOSStore(store);
+    const org = ws.organizations.insert({
+      object: 'organization',
+      name,
+      external_id: null,
+      metadata: {},
+      stripe_customer_id: null,
+    });
+    ws.organizationMemberships.insert({
+      object: 'organization_membership',
+      organization_id: org.id,
+      user_id: userId,
+      role: { slug: opts?.role ?? 'member' },
+      status: opts?.status ?? 'active',
+      external_id: null,
+      metadata: {},
+    });
+    return org;
+  }
+
+  /** Decode a JWT payload without verifying — these tests only inspect claims. */
+  function decodeJwt(token: string): Record<string, any> {
+    return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf-8'));
+  }
+
+  /** Mint a magic auth code for `email` and exchange it, as a client signing in would. */
+  async function signInWithMagicAuth(email: string) {
+    const magicRes = await req('/user_management/magic_auth', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+    const { code } = await json(magicRes);
+    return app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:magic-auth:code',
+        code,
+        email,
+      }),
+    });
+  }
+
   it('authorize redirects with code when user exists', async () => {
     await req('/user_management/users', {
       method: 'POST',
@@ -399,14 +444,9 @@ describe('Auth routes', () => {
 
   it('organization-selection grant scopes session to selected org', async () => {
     const user = await createUser('orgsel@test.com');
-    const ws = getWorkOSStore(store);
-    const org = ws.organizations.insert({
-      object: 'organization',
-      name: 'Test Org',
-      external_id: null,
-      metadata: {},
-      stripe_customer_id: null,
-    });
+    // The user must be an active member of the org they select — production issues no token
+    // for an organization the user does not belong to.
+    const org = joinOrg(user.id, 'Test Org');
 
     // Create a pending auth token
     const pendingToken = 'pending_test_token';
@@ -429,6 +469,288 @@ describe('Auth routes', () => {
     const body = await json(res);
     expect(body.organization_id).toBe(org.id);
     expect(body.user.email).toBe('orgsel@test.com');
+  });
+
+  it('organization-selection grant rejects an org the user does not actively belong to', async () => {
+    const user = await createUser('orgsel-outsider@test.com');
+    const other = await createUser('orgsel-insider@test.com');
+    const foreignOrg = joinOrg(other.id, 'Someone Elses Org');
+    const invitedOrg = joinOrg(user.id, 'Invited But Unaccepted', { status: 'pending' });
+
+    const pendingToken = 'pending_outsider_token';
+    const setPending = () =>
+      store.setData(`pending_auth:${pendingToken}`, {
+        user_id: user.id,
+        organization_id: null,
+        auth_method: 'Password',
+      });
+
+    const select = (organizationId: string) =>
+      app.request('/user_management/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'urn:workos:oauth:grant-type:organization-selection',
+          pending_authentication_token: pendingToken,
+          organization_id: organizationId,
+        }),
+      });
+
+    setPending();
+    const foreignRes = await select(foreignOrg.id);
+    expect(foreignRes.status).toBe(400);
+    expect((await json(foreignRes)).code).toBe('invalid_organization_id');
+
+    // A rejected selection must not consume the pending token: the client retries with another
+    // organization. An unaccepted invitation is not one it can pick.
+    const pendingRes = await select(invitedOrg.id);
+    expect(pendingRes.status).toBe(400);
+    expect((await json(pendingRes)).code).toBe('invalid_organization_id');
+  });
+
+  // --- Organization resolution on fresh logins ---
+
+  it('magic-auth resolves the single active organization onto the session and token', async () => {
+    const user = await createUser('solo-org@test.com');
+    const org = joinOrg(user.id, 'Solo Corp', { role: 'admin' });
+
+    const res = await signInWithMagicAuth('solo-org@test.com');
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.organization_id).toBe(org.id);
+
+    const claims = decodeJwt(body.access_token);
+    expect(claims.org_id).toBe(org.id);
+    expect(claims.role).toBe('admin');
+    expect(claims.roles).toEqual(['admin']);
+
+    // The session records the same organization the token claims.
+    const session = getWorkOSStore(store).sessions.get(claims.sid);
+    expect(session?.organization_id).toBe(org.id);
+  });
+
+  it('resolves the single active organization through the AuthKit hosted flow', async () => {
+    const user = await createUser('hosted@test.com');
+    const org = joinOrg(user.id, 'Hosted Corp');
+
+    // Codes are minted with organization_id: null, so the hosted flow relies entirely on the
+    // resolution step at the token endpoint.
+    const authRes = await app.request(
+      '/user_management/authorize?redirect_uri=http://localhost:3000/callback&response_type=code&login_hint=hosted@test.com',
+    );
+    const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!;
+
+    const tokenRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'authorization_code', code }),
+    });
+    expect(tokenRes.status).toBe(200);
+    const body = await json(tokenRes);
+    expect(body.organization_id).toBe(org.id);
+    expect(decodeJwt(body.access_token).org_id).toBe(org.id);
+  });
+
+  it('resolves the single active organization on password, email-verification and device_code', async () => {
+    const created = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'multi-grant@test.com', password: 'pw' }),
+    });
+    const user = await json(created);
+    const org = joinOrg(user.id, 'Grant Corp');
+
+    const passwordRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'password', email: 'multi-grant@test.com', password: 'pw' }),
+    });
+    expect((await json(passwordRes)).organization_id).toBe(org.id);
+
+    const ws = getWorkOSStore(store);
+    const verification = ws.emailVerifications.insert({
+      object: 'email_verification',
+      user_id: user.id,
+      email: user.email,
+      code: '424242',
+      expires_at: new Date(Date.now() + 600000).toISOString(),
+    });
+    const verifyRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:email-verification:code',
+        code: verification.code,
+        user_id: user.id,
+      }),
+    });
+    expect((await json(verifyRes)).organization_id).toBe(org.id);
+
+    const deviceRes = await req('/user_management/authorize/device', {
+      method: 'POST',
+      body: JSON.stringify({ client_id: 'test_client' }),
+    });
+    const device = await json(deviceRes);
+    const deviceTokenRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: device.device_code,
+      }),
+    });
+    expect((await json(deviceTokenRes)).organization_id).toBe(org.id);
+  });
+
+  it('returns organization_selection_required for a user with several active organizations', async () => {
+    const created = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'multi-org@test.com', password: 'pw' }),
+    });
+    const user = await json(created);
+    const first = joinOrg(user.id, 'Alpha Corp');
+    const second = joinOrg(user.id, 'Beta Corp');
+
+    const res = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'password', email: 'multi-org@test.com', password: 'pw' }),
+    });
+    expect(res.status).toBe(403);
+    const body = await json(res);
+    expect(body.code).toBe('organization_selection_required');
+    expect(body.pending_authentication_token).toBeTruthy();
+    expect(body.user.id).toBe(user.id);
+    expect(body.organizations).toEqual([
+      { id: first.id, name: 'Alpha Corp' },
+      { id: second.id, name: 'Beta Corp' },
+    ]);
+    // No session and no sign-in: the authentication is not finished until an org is chosen.
+    expect(body.access_token).toBeUndefined();
+    const ws = getWorkOSStore(store);
+    expect(ws.sessions.findBy('user_id', user.id)).toHaveLength(0);
+    expect(ws.users.get(user.id)?.last_sign_in_at).toBeNull();
+
+    // The pending token it hands back completes the sign-in against a chosen organization.
+    const selected = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:organization-selection',
+        pending_authentication_token: body.pending_authentication_token,
+        organization_id: second.id,
+      }),
+    });
+    expect(selected.status).toBe(200);
+    const selectedBody = await json(selected);
+    expect(selectedBody.organization_id).toBe(second.id);
+    expect(decodeJwt(selectedBody.access_token).org_id).toBe(second.id);
+    // The pending token recorded the primary factor, so the session reports it.
+    expect(selectedBody.authentication_method).toBe('Password');
+  });
+
+  it('requires the second factor before organization selection', async () => {
+    const created = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'mfa-multi-org@test.com', password: 'pw' }),
+    });
+    const user = await json(created);
+    joinOrg(user.id, 'Gamma Corp');
+    const chosen = joinOrg(user.id, 'Delta Corp');
+
+    const ws = getWorkOSStore(store);
+    ws.authFactors.insert({
+      object: 'authentication_factor',
+      user_id: user.id,
+      type: 'totp',
+      totp: { issuer: 'Test', user: user.email, uri: 'otpauth://...' },
+    });
+
+    // MFA comes first: the org is not resolved while the login is still unauthenticated.
+    const passwordRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'password', email: 'mfa-multi-org@test.com', password: 'pw' }),
+    });
+    expect(passwordRes.status).toBe(403);
+    const challengeBody = await json(passwordRes);
+    expect(challengeBody.code).toBe('mfa_challenge');
+
+    // The response withholds the one-time code, as production does; read it off the challenge.
+    const challengeCode = ws.authChallenges.get(challengeBody.authentication_challenge.id)!.code;
+
+    // Clearing the factor surfaces the organization choice, on a fresh pending token.
+    const mfaRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:mfa-totp',
+        code: challengeCode,
+        pending_authentication_token: challengeBody.pending_authentication_token,
+        authentication_challenge_id: challengeBody.authentication_challenge.id,
+      }),
+    });
+    expect(mfaRes.status).toBe(403);
+    const selectionBody = await json(mfaRes);
+    expect(selectionBody.code).toBe('organization_selection_required');
+    expect(selectionBody.pending_authentication_token).not.toBe(challengeBody.pending_authentication_token);
+
+    const selected = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:workos:oauth:grant-type:organization-selection',
+        pending_authentication_token: selectionBody.pending_authentication_token,
+        organization_id: chosen.id,
+      }),
+    });
+    expect(selected.status).toBe(200);
+    const selectedBody = await json(selected);
+    expect(selectedBody.organization_id).toBe(chosen.id);
+    // The primary factor survives both hops, so the session reports 'Password', not 'MFA'.
+    expect(selectedBody.authentication_method).toBe('Password');
+  });
+
+  it('ignores pending and inactive memberships when resolving an organization', async () => {
+    const user = await createUser('not-yet@test.com');
+    joinOrg(user.id, 'Unaccepted Invite', { status: 'pending' });
+    joinOrg(user.id, 'Deactivated', { status: 'inactive' });
+
+    const res = await signInWithMagicAuth('not-yet@test.com');
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.organization_id).toBeNull();
+    expect(decodeJwt(body.access_token).org_id).toBeUndefined();
+  });
+
+  it('leaves an unscoped session unscoped across a refresh', async () => {
+    const user = await createUser('later-member@test.com');
+
+    const signIn = await signInWithMagicAuth('later-member@test.com');
+    const { refresh_token } = await json(signIn);
+
+    // Joining an org mid-session must not silently upgrade the session's scope on refresh —
+    // only an explicit organization_id moves an existing session between organizations.
+    const org = joinOrg(user.id, 'Joined Later');
+
+    const refreshed = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'refresh_token', refresh_token }),
+    });
+    expect(refreshed.status).toBe(200);
+    const refreshedBody = await json(refreshed);
+    expect(refreshedBody.organization_id).toBeNull();
+
+    const switched = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshedBody.refresh_token,
+        organization_id: org.id,
+      }),
+    });
+    expect((await json(switched)).organization_id).toBe(org.id);
   });
 
   // --- MFA TOTP grant tests ---

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -470,14 +470,19 @@ export function authRoutes(ctx: RouteContext): void {
           );
         }
 
+        // A deferred invitation is revalidated before the challenge and pending token are consumed.
+        // One revoked or expired during the challenge still fails the request, but the state behind
+        // it survives, so a retry reports the same invitation_invalid rather than degrading into a
+        // confusing invalid_pending_authentication_token once the record is gone.
+        const deferredInvitation = pending.invitation_token ? resolveInvitation(pending.invitation_token) : null;
+
         ws.authChallenges.delete(challenge.id);
         store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, undefined);
 
         user = ws.users.get(pending.user_id);
         organizationId = pending.organization_id;
-        // An invitation supplied to the login that triggered this challenge is only accepted now,
-        // once the second factor has actually proven who is signing in.
-        if (pending.invitation_token) invitation = resolveInvitation(pending.invitation_token);
+        // Accepted further down, now that the second factor has proven who is signing in.
+        invitation = deferredInvitation;
         // Event is authentication.mfa_succeeded; the session records the primary factor the
         // pending token was issued for (MFA is a second factor, not a session auth method).
         authMethod = 'MFA';
@@ -520,10 +525,15 @@ export function authRoutes(ctx: RouteContext): void {
           );
         }
 
+        // An invitation deferred to the selection step (one naming no organization of its own) is
+        // revalidated on the same before-consumption rule as the MFA grant above.
+        const deferredInvitation = pending.invitation_token ? resolveInvitation(pending.invitation_token) : null;
+
         store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, undefined);
 
         user = ws.users.get(pending.user_id);
         organizationId = orgId;
+        invitation = deferredInvitation;
         authMethod = pending.auth_method;
         break;
       }
@@ -559,21 +569,22 @@ export function authRoutes(ctx: RouteContext): void {
     if (!user) throw notFound('User');
 
     // Accepting an invitation is the one way a caller can name the organization on a grant that
-    // takes no organization_id: the invitation joins the user and scopes the session, so it runs
-    // ahead of the implicit resolution below and wins over anything that grant had chosen.
-    if (invitation) {
-      // Compared case-insensitively: an invitation addressed to Foo@example.com is for the same
-      // person as foo@example.com, and rejecting on letter case alone would be a false negative.
-      if (invitation.email.toLowerCase() !== user.email.toLowerCase()) {
-        throw new WorkOSApiError(
-          400,
-          'The invitation was issued for a different email address',
-          'invitation_cannot_be_used_for_email',
-        );
-      }
-      const invitedOrgId = acceptInvitation(invitation, user, ws, store.getData<EventBus>(STORE_KEYS.eventBus));
-      if (invitedOrgId) organizationId = invitedOrgId;
+    // takes no organization_id, so an invitation's organization wins over anything the grant itself
+    // chose and settles the resolution below.
+    // Rejected before anything is consumed, so a token addressed to somebody else costs the caller
+    // neither their credential nor the invitation. Compared case-insensitively: an invitation to
+    // Foo@example.com is for the same person as foo@example.com, and rejecting on letter case alone
+    // would be a false negative.
+    if (invitation && invitation.email.toLowerCase() !== user.email.toLowerCase()) {
+      throw new WorkOSApiError(
+        400,
+        'The invitation was issued for a different email address',
+        'invitation_cannot_be_used_for_email',
+      );
     }
+    // The organization is read here, but the invitation is not spent until this request is known to
+    // be issuing a session — see the acceptance below the resolution step.
+    if (invitation?.organization_id) organizationId = invitation.organization_id;
 
     // Resolve the organization for any fresh login that hasn't already picked one. Production
     // does this on every grant: a single active membership is selected implicitly, several
@@ -603,12 +614,14 @@ export function authRoutes(ctx: RouteContext): void {
         // The spec documents the organization_selection_required code but not this response body
         // (as with mfa_challenge above); the pending token, organization list and user mirror
         // WorkOS. The pending token carries the method so the session the organization-selection
-        // grant eventually creates reports the original factor rather than 'unknown'.
+        // grant eventually creates reports the original factor rather than 'unknown', and any
+        // still-unspent invitation so the selection step can finish accepting it.
         const pendingToken = generateId('pending');
         store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, {
           user_id: user.id,
           organization_id: null,
           auth_method: sessionAuthMethod ?? authMethod,
+          invitation_token: invitation?.token ?? null,
         });
         return c.json(
           {
@@ -621,6 +634,14 @@ export function authRoutes(ctx: RouteContext): void {
           403,
         );
       }
+    }
+
+    // Past every continuation check, so this request is the one issuing a session. Spending the
+    // invitation only now is what stops a one-time invitation being burned by an mfa_challenge or
+    // organization_selection_required response the client may never come back from — and it still
+    // lands before the role lookup below, which reads the membership it creates.
+    if (invitation) {
+      acceptInvitation(invitation, user, ws, store.getData<EventBus>(STORE_KEYS.eventBus));
     }
 
     // A fresh login creates a new session (firing session.created); a refresh_token rotation

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -15,8 +15,10 @@ import {
   emitAuthenticationEvent,
   generateCode,
   formatAuthChallenge,
+  acceptInvitation,
 } from '../helpers.js';
 import type { EventBus } from '../event-bus.js';
+import type { WorkOSInvitation } from '../entities.js';
 import { STORE_KEYS, STORE_KEY_PREFIXES } from '../constants.js';
 import { renderLoginPage } from '../login-page.js';
 
@@ -24,7 +26,21 @@ interface PendingAuth {
   user_id: string;
   organization_id: string | null;
   auth_method: string;
+  /** Carried across an MFA challenge so the second factor doesn't drop a pending invitation. */
+  invitation_token?: string | null;
 }
+
+/**
+ * The grants whose request schema carries `invitation_token`. Production has nowhere to put one on
+ * any other grant, so it is ignored rather than honored there — accepting it everywhere would let
+ * a call that works against the emulator silently skip the invitation in production.
+ */
+const INVITATION_TOKEN_GRANTS = new Set([
+  'authorization_code',
+  'password',
+  'urn:workos:oauth:grant-type:magic-auth',
+  'urn:workos:oauth:grant-type:magic-auth:code',
+]);
 
 interface AuthorizeParams {
   redirectUri: string;
@@ -167,6 +183,27 @@ export function authRoutes(ctx: RouteContext): void {
     const requestIp = c.req.header('x-forwarded-for') ?? null;
     const requestUserAgent = c.req.header('user-agent') ?? null;
 
+    /** Resolve an invitation token, rejecting one that is unknown, expired or already used. */
+    const resolveInvitation = (token: string): WorkOSInvitation => {
+      const inv = ws.invitations.findOneBy('token', token);
+      if (!inv || inv.state !== 'pending' || isExpired(inv.expires_at)) {
+        throw new WorkOSApiError(
+          400,
+          'The invitation is invalid, expired, or has already been accepted',
+          'invitation_invalid',
+        );
+      }
+      return inv;
+    };
+
+    // Resolved before the grant runs so a bad invitation cannot burn the one-time code or
+    // authorization code the same request carries; the recipient check waits until the grant has
+    // told us who is signing in.
+    let invitation: WorkOSInvitation | null =
+      INVITATION_TOKEN_GRANTS.has(grantType) && body.invitation_token
+        ? resolveInvitation(body.invitation_token as string)
+        : null;
+
     /** Emit the spec's authentication.*_failed event for a credential failure, then throw. */
     const failAuth: (
       method: string,
@@ -204,6 +241,7 @@ export function authRoutes(ctx: RouteContext): void {
         user_id: mfaUser.id,
         organization_id: orgId,
         auth_method: primaryMethod,
+        invitation_token: invitation?.token ?? null,
       });
       const challenge = ws.authChallenges.insert({
         object: 'authentication_challenge',
@@ -437,6 +475,9 @@ export function authRoutes(ctx: RouteContext): void {
 
         user = ws.users.get(pending.user_id);
         organizationId = pending.organization_id;
+        // An invitation supplied to the login that triggered this challenge is only accepted now,
+        // once the second factor has actually proven who is signing in.
+        if (pending.invitation_token) invitation = resolveInvitation(pending.invitation_token);
         // Event is authentication.mfa_succeeded; the session records the primary factor the
         // pending token was issued for (MFA is a second factor, not a session auth method).
         authMethod = 'MFA';
@@ -475,7 +516,7 @@ export function authRoutes(ctx: RouteContext): void {
           throw new WorkOSApiError(
             400,
             'The user is not an active member of the selected organization',
-            'invalid_organization_id',
+            'organization_membership_not_found',
           );
         }
 
@@ -516,6 +557,23 @@ export function authRoutes(ctx: RouteContext): void {
     }
 
     if (!user) throw notFound('User');
+
+    // Accepting an invitation is the one way a caller can name the organization on a grant that
+    // takes no organization_id: the invitation joins the user and scopes the session, so it runs
+    // ahead of the implicit resolution below and wins over anything that grant had chosen.
+    if (invitation) {
+      // Compared case-insensitively: an invitation addressed to Foo@example.com is for the same
+      // person as foo@example.com, and rejecting on letter case alone would be a false negative.
+      if (invitation.email.toLowerCase() !== user.email.toLowerCase()) {
+        throw new WorkOSApiError(
+          400,
+          'The invitation was issued for a different email address',
+          'invitation_cannot_be_used_for_email',
+        );
+      }
+      const invitedOrgId = acceptInvitation(invitation, user, ws, store.getData<EventBus>(STORE_KEYS.eventBus));
+      if (invitedOrgId) organizationId = invitedOrgId;
+    }
 
     // Resolve the organization for any fresh login that hasn't already picked one. Production
     // does this on every grant: a single active membership is selected implicitly, several

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -464,6 +464,21 @@ export function authRoutes(ctx: RouteContext): void {
         const org = ws.organizations.get(orgId);
         if (!org) throw notFound('Organization');
 
+        // Production only scopes a session to an organization the user actually belongs to.
+        // Unvalidated, a client could select any organization id and receive a token whose
+        // org_id claim production would never issue. Checked before the pending token is
+        // consumed, so a client that picks the wrong organization can retry with the right one.
+        const selectable = ws.organizationMemberships
+          .findBy('organization_id', orgId)
+          .find((m) => m.user_id === pending.user_id && m.status === 'active');
+        if (!selectable) {
+          throw new WorkOSApiError(
+            400,
+            'The user is not an active member of the selected organization',
+            'invalid_organization_id',
+          );
+        }
+
         store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, undefined);
 
         user = ws.users.get(pending.user_id);
@@ -501,6 +516,54 @@ export function authRoutes(ctx: RouteContext): void {
     }
 
     if (!user) throw notFound('User');
+
+    // Resolve the organization for any fresh login that hasn't already picked one. Production
+    // does this on every grant: a single active membership is selected implicitly, several
+    // return organization_selection_required so the client can choose. Only three of the grants
+    // above set organizationId themselves, and authorization_code reads it off a code minted
+    // with organization_id: null — so without this step magic-auth, password, email-verification,
+    // device_code and the whole AuthKit hosted flow could each mint only an unscoped session,
+    // and anything authorizing on the org_id claim rejected every token the emulator issued.
+    //
+    // Runs before the session is created so the session records the resolved organization and a
+    // selection-required response leaves behind neither a session nor a sign-in timestamp. A
+    // refresh is excluded: it reuses a session whose scope is already settled, and an explicit
+    // body.organization_id stays the only way to move an existing session between orgs.
+    if (isFreshLogin && !organizationId) {
+      const selectableOrgs: Array<{ id: string; name: string }> = [];
+      for (const m of ws.organizationMemberships.findBy('user_id', user.id)) {
+        // 'pending' is an unaccepted invitation and 'inactive' a deactivated member; neither is
+        // an organization production would scope a session to.
+        if (m.status !== 'active') continue;
+        const org = ws.organizations.get(m.organization_id);
+        if (org) selectableOrgs.push({ id: org.id, name: org.name });
+      }
+
+      if (selectableOrgs.length === 1) {
+        organizationId = selectableOrgs[0].id;
+      } else if (selectableOrgs.length > 1) {
+        // The spec documents the organization_selection_required code but not this response body
+        // (as with mfa_challenge above); the pending token, organization list and user mirror
+        // WorkOS. The pending token carries the method so the session the organization-selection
+        // grant eventually creates reports the original factor rather than 'unknown'.
+        const pendingToken = generateId('pending');
+        store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, {
+          user_id: user.id,
+          organization_id: null,
+          auth_method: sessionAuthMethod ?? authMethod,
+        });
+        return c.json(
+          {
+            code: 'organization_selection_required',
+            message: 'The user must choose an organization to finish their authentication.',
+            pending_authentication_token: pendingToken,
+            organizations: selectableOrgs,
+            user: formatUser(user),
+          },
+          403,
+        );
+      }
+    }
 
     // A fresh login creates a new session (firing session.created); a refresh_token rotation
     // reuses the existing session, so it emits neither session.created nor an auth event.
@@ -552,6 +615,9 @@ export function authRoutes(ctx: RouteContext): void {
       sid: session.id,
       org_id: organizationId ?? undefined,
       role: roleSlug,
+      // Production emits the plural `roles` alongside `role`; the emulator models one role per
+      // membership, so it is that role as a single-element array.
+      roles: roleSlug ? [roleSlug] : undefined,
       permissions: permissionSlugs,
       aud: clientId ?? 'workos-emulate',
     });

--- a/src/workos/routes/invitations.ts
+++ b/src/workos/routes/invitations.ts
@@ -7,7 +7,13 @@ import {
   parseListParams,
 } from '../../core/index.js';
 import { getWorkOSStore } from '../store.js';
-import { formatInvitation, generateVerificationToken, expiresIn, formatListResponse } from '../helpers.js';
+import {
+  formatInvitation,
+  generateVerificationToken,
+  expiresIn,
+  formatListResponse,
+  acceptInvitation,
+} from '../helpers.js';
 import type { EventBus } from '../event-bus.js';
 import { STORE_KEYS, EVENTS } from '../constants.js';
 
@@ -76,25 +82,7 @@ export function invitationRoutes(ctx: RouteContext): void {
       throw new WorkOSApiError(400, `Invitation is ${inv.state}`, 'invalid_invitation_state');
     }
 
-    ws.invitations.update(inv.id, { state: 'accepted' });
-    const eventBus = store.getData<EventBus>(STORE_KEYS.eventBus);
-    eventBus?.emit({ event: EVENTS.invitationAccepted, data: formatInvitation(ws.invitations.get(inv.id)!) });
-
-    // Create org membership if invitation has an organization
-    if (inv.organization_id) {
-      const user = ws.users.findOneBy('email', inv.email);
-      if (user) {
-        ws.organizationMemberships.insert({
-          object: 'organization_membership',
-          organization_id: inv.organization_id,
-          user_id: user.id,
-          role: { slug: inv.role_slug ?? 'member' },
-          status: 'active',
-          external_id: null,
-          metadata: {},
-        });
-      }
-    }
+    acceptInvitation(inv, ws.users.findOneBy('email', inv.email), ws, store.getData<EventBus>(STORE_KEYS.eventBus));
 
     const updated = ws.invitations.get(inv.id)!;
     return c.json(formatInvitation(updated));


### PR DESCRIPTION
## Summary

- **Fresh logins now resolve an organization.** Every grant except `mfa-totp`, `organization-selection`, and a refresh carrying an explicit `organization_id` could only mint an unscoped session. Tokens therefore never carried `org_id`, `role`, or `permissions`, so any API authorizing on the org claim rejected every token the emulator issued. A single active membership is now selected implicitly; several return `organization_selection_required` (403) as production does; none leaves `organization_id` null rather than inventing one.
- **The organization-selection grant is reachable and validated.** `organization_selection_required` was never emitted, so the grant was unreachable except after an MFA challenge; it also never checked that the user was an active member of the organization it was handed. It does now, reporting `organization_membership_not_found` (the spec's code for that case, previously mis-reported as `invalid_organization_id`), and it checks before consuming the pending token so a wrong pick can be retried.
- **`invitation_token` is honored on `authorization_code`, `password`, and Magic Auth.** It is the only way a caller can name an organization on a grant that takes no `organization_id`. The emulator ignored the field entirely, so an invited user landed in an unscoped session, the invitation stayed pending forever, and a multi-organization user hit a selection prompt they should never have seen. The token is validated _before_ the grant runs so a bad invitation can't burn the one-time code in the same request, and it's carried across an MFA challenge rather than accepted early, so nothing is consumed until the second factor proves who is signing in.
- **Invitation acceptance is shared with the invitations REST route**, which previously duplicated a membership when one already existed and could not readmit a deactivated member.
- **Access tokens now carry `roles` alongside `role`.** Production emits both and the WorkOS SDKs read the plural; a token with only `role` passed locally and lost the claim in production.

## Breaking change

Multi-organization users now receive a `403 organization_selection_required` where they previously received a `200` with a null organization. This matches production, but any test fixture relying on the old unscoped response will need to complete the selection step.
