### PR TITLE
fix(webhooks): match the WorkOS signature header

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Codes that WorkOS would deliver by email are delivered to you in the webhook pay
 
 ### 3. Verify signatures
 
-Webhooks are signed exactly like production WorkOS: `WorkOS-Signature: t=<timestamp>,v1=<hmac>` where the HMAC-SHA256 is computed over `"{timestamp}.{body}"` with the endpoint's secret. The official SDKs' `webhooks.constructEvent` verifies them unchanged.
+Webhooks are signed exactly like production WorkOS: `WorkOS-Signature: t=<timestamp>, v1=<hmac>` where the HMAC-SHA256 is computed over `"{timestamp}.{body}"` with the endpoint's secret. The official SDKs' `webhooks.constructEvent` verifies them unchanged.
 
 ### Organization-scoped sessions
 

--- a/scripts/smoke-node.mjs
+++ b/scripts/smoke-node.mjs
@@ -105,7 +105,7 @@ try {
 }
 
 function verifyWebhookSignature(signature, rawBody) {
-  const match = signature?.match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+  const match = signature?.match(/^t=(\d+), v1=([a-f0-9]{64})$/);
   assert.ok(match, `unexpected WorkOS-Signature: ${signature}`);
   const expected = createHmac('sha256', webhookSecret).update(`${match[1]}.${rawBody}`).digest('hex');
   assert.equal(match[2], expected);

--- a/src/e2e.spec.ts
+++ b/src/e2e.spec.ts
@@ -98,9 +98,9 @@ describe('end-to-end login flow (workos.com/docs story)', () => {
     );
   }
 
-  /** WorkOS-Signature: t=<unix>,v1=<hmac-sha256 of "t.body"> — same scheme the official SDKs verify. */
+  /** WorkOS-Signature: t=<unix-ms>, v1=<hmac-sha256 of "t.body"> — same scheme the official SDKs verify. */
   function verifySignature(webhook: ReceivedWebhook): void {
-    const match = webhook.signature?.match(/^t=(\d+),v1=([a-f0-9]{64})$/);
+    const match = webhook.signature?.match(/^t=(\d+), v1=([a-f0-9]{64})$/);
     expect(match, `unexpected signature format: ${webhook.signature}`).toBeTruthy();
     const expected = createHmac('sha256', webhookSecret).update(`${match![1]}.${webhook.rawBody}`).digest('hex');
     expect(match![2]).toBe(expected);

--- a/src/workos/event-bus.spec.ts
+++ b/src/workos/event-bus.spec.ts
@@ -119,10 +119,10 @@ describe('EventBus', () => {
     receivedSignature = (init!.headers as Record<string, string>)['WorkOS-Signature'];
 
     // Verify signature format
-    expect(receivedSignature).toMatch(/^t=\d+,v1=[a-f0-9]{64}$/);
+    expect(receivedSignature).toMatch(/^t=\d{13}, v1=[a-f0-9]{64}$/);
 
     // Verify HMAC is correct
-    const match = receivedSignature!.match(/^t=(\d+),v1=([a-f0-9]+)$/)!;
+    const match = receivedSignature!.match(/^t=(\d+), v1=([a-f0-9]+)$/)!;
     const [, timestamp, hash] = match;
     const expectedHash = createHmac('sha256', secret).update(`${timestamp}.${receivedBody}`).digest('hex');
     expect(hash).toBe(expectedHash);

--- a/src/workos/webhook-signer.spec.ts
+++ b/src/workos/webhook-signer.spec.ts
@@ -3,9 +3,9 @@ import { createHmac } from 'node:crypto';
 import { signWebhookPayload } from './webhook-signer.js';
 
 describe('signWebhookPayload', () => {
-  it('returns signature in t=...,v1=... format', () => {
+  it('returns signature in t=..., v1=... format with millisecond timestamp', () => {
     const sig = signWebhookPayload('{"test":true}', 'secret123');
-    expect(sig).toMatch(/^t=\d+,v1=[a-f0-9]{64}$/);
+    expect(sig).toMatch(/^t=\d{13}, v1=[a-f0-9]{64}$/);
   });
 
   it('produces verifiable HMAC-SHA256 signature', () => {
@@ -13,7 +13,7 @@ describe('signWebhookPayload', () => {
     const secret = 'whsec_test_key';
     const sig = signWebhookPayload(payload, secret);
 
-    const match = sig.match(/^t=(\d+),v1=([a-f0-9]+)$/);
+    const match = sig.match(/^t=(\d+), v1=([a-f0-9]+)$/);
     expect(match).toBeTruthy();
 
     const [, timestamp, hash] = match!;
@@ -27,8 +27,8 @@ describe('signWebhookPayload', () => {
     const sig1 = signWebhookPayload(payload, 'secret_a');
     const sig2 = signWebhookPayload(payload, 'secret_b');
 
-    const hash1 = sig1.split(',v1=')[1];
-    const hash2 = sig2.split(',v1=')[1];
+    const hash1 = sig1.split(', v1=')[1];
+    const hash2 = sig2.split(', v1=')[1];
     expect(hash1).not.toBe(hash2);
   });
 });

--- a/src/workos/webhook-signer.ts
+++ b/src/workos/webhook-signer.ts
@@ -1,9 +1,9 @@
 import { createHmac } from 'node:crypto';
 
 export function signWebhookPayload(payload: string, secret: string): string {
-  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const timestamp = Date.now().toString();
   const signedPayload = `${timestamp}.${payload}`;
   const signature = createHmac('sha256', secret).update(signedPayload).digest('hex');
 
-  return `t=${timestamp},v1=${signature}`;
+  return `t=${timestamp}, v1=${signature}`;
 }


### PR DESCRIPTION
- Emit millisecond timestamps and `t=<ts>, v1=<hmac>` (comma-space) in `signWebhookPayload`, matching the documented WorkOS header.
- The previous seconds-precision, no-space header was rejected by the Go SDK (fatal timestamp + signature parse) and the Node SDK (tolerance check), so every emulated delivery failed verification.
- Updates existing signature assertions across the webhook, event-bus, and e2e specs.

Closes #35, closes #36
