### PR TITLE
fix(jwt-template): mirror production context for org domains, user, org, and membership

### DIFF
--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -18,6 +18,7 @@ export interface WorkOSOrganization extends Entity {
   external_id: string | null;
   metadata: Record<string, string>;
   stripe_customer_id: string | null;
+  allow_profiles_outside_organization: boolean;
 }
 
 export interface WorkOSOrganizationDomain extends Entity {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -73,21 +73,30 @@ export function formatOrganization(
 ): Record<string, unknown> {
   const domains = (opts?.domains ?? ws.organizationDomains.findBy('organization_id', org.id)).map(formatDomain);
 
-  return {
+  const result: Record<string, unknown> = {
     object: 'organization',
     id: org.id,
     name: org.name,
+    allow_profiles_outside_organization: org.allow_profiles_outside_organization,
     external_id: org.external_id,
     metadata: org.metadata,
     domains,
-    stripe_customer_id: org.stripe_customer_id,
     created_at: org.created_at,
     updated_at: org.updated_at,
   };
+
+  // Production omits stripe_customer_id when it is null rather than emitting it.
+  if (org.stripe_customer_id !== null) {
+    result.stripe_customer_id = org.stripe_customer_id;
+  }
+
+  return result;
 }
 
+const DOMAIN_EXCLUDE = new Set([...INTERNAL_FIELDS, 'verification_token', 'verification_prefix']);
+
 export function formatDomain(domain: WorkOSOrganizationDomain): Record<string, unknown> {
-  return formatEntity(domain);
+  return formatEntity(domain, { exclude: DOMAIN_EXCLUDE });
 }
 
 export function formatMembership(m: WorkOSOrganizationMembership, ws: WorkOSStore): Record<string, unknown> {

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -86,6 +86,7 @@ export interface WorkOSSeedOrganization {
   external_id?: string;
   metadata?: Record<string, string>;
   domains?: Array<{ domain: string; state?: 'verified' | 'pending' }>;
+  allow_profiles_outside_organization?: boolean;
   memberships?: Array<{
     /**
      * Email of a user defined in `users`. Seeded user ids are generated at startup,
@@ -296,6 +297,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: WorkOSSee
         external_id: orgConfig.external_id ?? null,
         metadata: orgConfig.metadata ?? {},
         stripe_customer_id: null,
+        allow_profiles_outside_organization: orgConfig.allow_profiles_outside_organization ?? false,
       });
 
       if (orgConfig.domains) {

--- a/src/workos/jwt-template-integration.spec.ts
+++ b/src/workos/jwt-template-integration.spec.ts
@@ -161,6 +161,43 @@ describe('JWT templates end to end', () => {
     expect(ws.users.findOneBy('email', 'alice@acme.com')?.last_sign_in_at).toBeNull();
   });
 
+  it('renders the full organization_domain in template claims', async () => {
+    emulator = await createEmulator({
+      port: 0,
+      seed: {
+        ...seed,
+        organizations: [
+          {
+            name: 'Acme Corp',
+            domains: [{ domain: 'acme.com', state: 'verified' as const }],
+            memberships: [{ email: 'alice@acme.com', role: 'admin', status: 'active' as const }],
+          },
+        ],
+        jwtTemplate: {
+          content: '{"urn:example:domains": {{ organization.domains }}}',
+        },
+      },
+    });
+
+    const { status, body } = await login(emulator.url);
+    expect(status).toBe(200);
+
+    const claims = decode(body.access_token);
+    const domains = claims['urn:example:domains'] as Array<Record<string, unknown>>;
+    expect(domains).toHaveLength(1);
+    expect(domains[0].object).toBe('organization_domain');
+    expect(domains[0].organization_id).toBeString();
+    expect(domains[0].domain).toBe('acme.com');
+    expect(domains[0].state).toBe('verified');
+    expect(domains[0].verification_strategy).toBe('manual');
+    expect(domains[0].created_at).toBeString();
+    expect(domains[0].updated_at).toBeString();
+    // verification_token/verification_prefix must not leak into the claim.
+    const flat = JSON.stringify(domains);
+    expect(flat).not.toContain('verification_token');
+    expect(flat).not.toContain('verification_prefix');
+  });
+
   it('signs nothing extra when no template is configured', async () => {
     emulator = await createEmulator({ port: 0, seed });
     const { body } = await login(emulator.url);

--- a/src/workos/jwt-template-integration.spec.ts
+++ b/src/workos/jwt-template-integration.spec.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, afterEach } from 'bun:test';
 import { generateKeyPairSync } from 'node:crypto';
 import { createEmulator, type Emulator } from '../index.js';
 import { getWorkOSStore } from './store.js';
+import { buildJwtTemplateContext } from './jwt-template.js';
 
 describe('JWT templates end to end', () => {
   let emulator: Emulator | undefined;
@@ -213,6 +214,125 @@ describe('JWT templates end to end', () => {
       'sid',
       'sub',
     ]);
+  });
+
+  // The context objects must mirror the production WorkOS JWT template context shapes,
+  // which were measured by minting real tokens against api.workos.com.
+  describe('buildJwtTemplateContext mirrors production shapes', () => {
+    it('builds the user context with all prod fields and no last_sign_in_at', async () => {
+      emulator = await createEmulator({ port: 0, seed });
+      const ws = getWorkOSStore(emulator.store);
+      const user = ws.users.findOneBy('email', 'alice@acme.com')!;
+
+      const ctx = buildJwtTemplateContext(ws, user, null);
+      const u = ctx.user!;
+
+      expect(u.object).toBe('user');
+      expect(u.id).toBeString();
+      expect(u.email).toBe('alice@acme.com');
+      expect(u.first_name).toBe('Alice');
+      expect(u.last_name).toBe('Smith');
+      expect(u.email_verified).toBe(false);
+      expect(u.profile_picture_url).toBeNull();
+      expect(u.created_at).toBeString();
+      expect(u.updated_at).toBeString();
+      expect(u.metadata).toEqual({});
+      expect(u.external_id).toBeNull();
+      expect(u.locale).toBeNull();
+      expect(u.last_sign_in_at).toBeUndefined();
+      expect(u.password_hash).toBeUndefined();
+      expect(u.impersonator).toBeUndefined();
+      expect(u.oauth_provider).toBeUndefined();
+
+      const identities = u.identities as Record<string, null>;
+      expect(identities).toEqual({
+        AppleOAuth: null,
+        GitHubOAuth: null,
+        GoogleOAuth: null,
+        GrokOAuth: null,
+        IntuitOAuth: null,
+        LinkedInOAuth: null,
+        MicrosoftOAuth: null,
+        VercelMarketplaceOAuth: null,
+        VercelOAuth: null,
+        SalesforceOAuth: null,
+      });
+    });
+
+    it('builds the organization context with prod fields and no null stripe_customer_id', async () => {
+      emulator = await createEmulator({
+        port: 0,
+        seed: {
+          ...seed,
+          organizations: [
+            {
+              name: 'Acme Corp',
+              domains: [{ domain: 'acme.com', state: 'verified' as const }],
+              memberships: [{ email: 'alice@acme.com', role: 'admin', status: 'active' as const }],
+            },
+          ],
+        },
+      });
+      const ws = getWorkOSStore(emulator.store);
+      const user = ws.users.findOneBy('email', 'alice@acme.com')!;
+      const org = ws.organizations.findOneBy('name', 'Acme Corp')!;
+
+      const ctx = buildJwtTemplateContext(ws, user, org.id);
+      const o = ctx.organization!;
+
+      expect(o.object).toBe('organization');
+      expect(o.id).toBe(org.id);
+      expect(o.name).toBe('Acme Corp');
+      expect(o.allow_profiles_outside_organization).toBe(false);
+      expect(o.created_at).toBeString();
+      expect(o.updated_at).toBeString();
+      expect(o.metadata).toEqual({});
+      expect(o.external_id).toBeNull();
+      // stripe_customer_id is omitted when null (prod drops it).
+      expect(o.stripe_customer_id).toBeUndefined();
+
+      const domains = o.domains as Array<Record<string, unknown>>;
+      expect(domains).toHaveLength(1);
+      const d = domains[0];
+      expect(Object.keys(d).sort()).toEqual(
+        [
+          'object',
+          'id',
+          'organization_id',
+          'domain',
+          'state',
+          'verification_strategy',
+          'created_at',
+          'updated_at',
+        ].sort(),
+      );
+      expect(d.verification_token).toBeUndefined();
+      expect(d.verification_prefix).toBeUndefined();
+    });
+
+    it('builds the membership context with prod-only fields', async () => {
+      emulator = await createEmulator({ port: 0, seed });
+      const ws = getWorkOSStore(emulator.store);
+      const user = ws.users.findOneBy('email', 'alice@acme.com')!;
+      const org = ws.organizations.findOneBy('name', 'Acme Corp')!;
+
+      const ctx = buildJwtTemplateContext(ws, user, org.id);
+      const m = ctx.organization_membership!;
+
+      expect(m.object).toBe('organization_membership');
+      expect(m.id).toBeString();
+      expect(m.role).toBe('admin');
+      expect(m.roles).toEqual(['admin']);
+      expect(m.created_at).toBeString();
+      expect(m.updated_at).toBeString();
+      expect(m.custom_attributes).toEqual({});
+      // Prod omits these from the context (they are on the API response but not the context).
+      expect(m.external_id).toBeUndefined();
+      expect(m.metadata).toBeUndefined();
+      expect(m.organization_id).toBeUndefined();
+      expect(m.user_id).toBeUndefined();
+      expect(m.status).toBeUndefined();
+    });
   });
 });
 

--- a/src/workos/jwt-template.spec.ts
+++ b/src/workos/jwt-template.spec.ts
@@ -135,7 +135,9 @@ describe('renderJwtTemplate', () => {
   });
 
   it('resolves an unmodelled path below a known root to null', () => {
-    expect(render('{"x": "{{ organization.allow_profiles_outside_organization || \'unset\' }}"}')).toEqual({
+    // user.name is not on the emulator entity yet (PR #43 adds it); until then it
+    // resolves to null so a fallback can cover it.
+    expect(render('{"x": "{{ user.name || \'unset\' }}"}')).toEqual({
       x: 'unset',
     });
   });

--- a/src/workos/jwt-template.spec.ts
+++ b/src/workos/jwt-template.spec.ts
@@ -19,7 +19,28 @@ const context: JwtTemplateContext = {
   organization: {
     id: 'org_01XYZ',
     name: 'Acme Corp',
-    domains: [{ domain: 'acme.com' }, { domain: 'acme.dev' }],
+    domains: [
+      {
+        object: 'organization_domain',
+        id: 'org_domain_01A',
+        organization_id: 'org_01XYZ',
+        domain: 'acme.com',
+        state: 'verified',
+        verification_strategy: 'manual',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        object: 'organization_domain',
+        id: 'org_domain_01B',
+        organization_id: 'org_01XYZ',
+        domain: 'acme.dev',
+        state: 'pending',
+        verification_strategy: 'dns',
+        created_at: '2026-01-02T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+      },
+    ],
     metadata: {},
   },
   organization_membership: {
@@ -81,6 +102,36 @@ describe('renderJwtTemplate', () => {
 
   it('drops reserved claims as a backstop', () => {
     expect(render('{"sub": "spoofed", "keep": "{{ user.id }}"}')).toEqual({ keep: 'user_01ABC' });
+  });
+
+  it('renders the full organization_domain object in organization.domains', () => {
+    const result = render('{"domains": {{ organization.domains }}}');
+    expect(result.domains).toEqual([
+      {
+        object: 'organization_domain',
+        id: 'org_domain_01A',
+        organization_id: 'org_01XYZ',
+        domain: 'acme.com',
+        state: 'verified',
+        verification_strategy: 'manual',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        object: 'organization_domain',
+        id: 'org_domain_01B',
+        organization_id: 'org_01XYZ',
+        domain: 'acme.dev',
+        state: 'pending',
+        verification_strategy: 'dns',
+        created_at: '2026-01-02T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+      },
+    ]);
+    // verification_token/verification_prefix must not appear in the rendered object.
+    const flat = JSON.stringify(result.domains);
+    expect(flat).not.toContain('verification_token');
+    expect(flat).not.toContain('verification_prefix');
   });
 
   it('resolves an unmodelled path below a known root to null', () => {

--- a/src/workos/jwt-template.ts
+++ b/src/workos/jwt-template.ts
@@ -18,6 +18,7 @@ import { type Store, WorkOSApiError } from '../core/index.js';
 import type { WorkOSStore } from './store.js';
 import type { WorkOSJwtTemplate, WorkOSUser } from './entities.js';
 import { STORE_KEYS } from './constants.js';
+import { formatUser, formatOrganization } from './helpers.js';
 
 /**
  * Claims a template may not set. WorkOS rejects these at template-update time, so the
@@ -189,24 +190,50 @@ export function renderJwtTemplate(content: string, context: JwtTemplateContext):
 }
 
 /**
+ * The OAuth provider keys observed in the production JWT template context's
+ * `user.identities` map. The emulator does not model identity linking, so every
+ * provider maps to null — matching a user with no linked identities. Note
+ * GitHubOAuth uses a capital-H per the measured production context.
+ */
+const OAUTH_IDENTITIES_MAP: Record<string, null> = {
+  AppleOAuth: null,
+  GitHubOAuth: null,
+  GoogleOAuth: null,
+  GrokOAuth: null,
+  IntuitOAuth: null,
+  LinkedInOAuth: null,
+  MicrosoftOAuth: null,
+  VercelMarketplaceOAuth: null,
+  VercelOAuth: null,
+  SalesforceOAuth: null,
+};
+
+/**
  * Representative values used to render a template at validation time, so syntax errors,
  * unknown variables, and reserved claims surface when the template is set rather than at
  * the next sign-in. Only the shape matters — these values never reach a token.
  */
 const PROBE_CONTEXT: JwtTemplateContext = {
   user: {
+    object: 'user',
     id: 'user_01PROBE',
     email: 'probe@example.com',
     first_name: 'Probe',
     last_name: 'User',
     email_verified: true,
     profile_picture_url: null,
-    external_id: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
     metadata: {},
+    external_id: null,
+    locale: null,
+    identities: OAUTH_IDENTITIES_MAP,
   },
   organization: {
+    object: 'organization',
     id: 'org_01PROBE',
     name: 'Probe Org',
+    allow_profiles_outside_organization: false,
     domains: [
       {
         object: 'organization_domain',
@@ -219,14 +246,19 @@ const PROBE_CONTEXT: JwtTemplateContext = {
         updated_at: '2026-01-01T00:00:00.000Z',
       },
     ],
-    stripe_customer_id: null,
     external_id: null,
     metadata: {},
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
   },
   organization_membership: {
+    object: 'organization_membership',
     id: 'om_01PROBE',
     role: 'member',
     roles: ['member'],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    custom_attributes: {},
   },
 };
 
@@ -261,50 +293,37 @@ export function validateJwtTemplateContent(content: unknown): string[] {
 }
 
 /**
- * Assemble the variables a template can read for one sign-in. Fields the emulator does not
- * model — `organization.allow_profiles_outside_organization` and
- * `organization_membership.custom_attributes` among them — are left out rather than filled
- * with a plausible value, so a template referencing them resolves to null.
+ * Assemble the variables a template can read for one sign-in. Mirrors the production
+ * WorkOS JWT template context: `user` and `organization` are built from the format*
+ * helpers (so they track the API response shape), with the adjustments prod's template
+ * context makes on top — `user.identities` is added (a provider→null map for users with
+ * no linked identity) and `user.last_sign_in_at` is dropped. `organization_membership`
+ * is built explicitly with the context-only shape (string `role`/`roles`, no
+ * `external_id`/`metadata`).
+ *
+ * `user.name` is not on the emulator's user entity yet; it will auto-appear via
+ * formatUser once PR #43 adds it. No change here will be needed when that lands.
  */
 export function buildJwtTemplateContext(
   ws: WorkOSStore,
   user: WorkOSUser,
   organizationId?: string | null,
 ): JwtTemplateContext {
-  const context: JwtTemplateContext = {
-    user: {
-      id: user.id,
-      email: user.email,
-      first_name: user.first_name,
-      last_name: user.last_name,
-      email_verified: user.email_verified,
-      profile_picture_url: user.profile_picture_url,
-      external_id: user.external_id,
-      metadata: user.metadata,
-    },
+  const userContext: Record<string, unknown> = {
+    ...formatUser(user),
+    identities: OAUTH_IDENTITIES_MAP,
   };
+  // `last_sign_in_at` is on the API response but omitted from the JWT template context
+  // by production.
+  delete userContext.last_sign_in_at;
+
+  const context: JwtTemplateContext = { user: userContext };
 
   if (!organizationId) return context;
 
   const organization = ws.organizations.get(organizationId);
   if (organization) {
-    context.organization = {
-      id: organization.id,
-      name: organization.name,
-      domains: ws.organizationDomains.findBy('organization_id', organization.id).map((domain) => ({
-        object: domain.object,
-        id: domain.id,
-        organization_id: domain.organization_id,
-        domain: domain.domain,
-        state: domain.state,
-        verification_strategy: domain.verification_strategy,
-        created_at: domain.created_at,
-        updated_at: domain.updated_at,
-      })),
-      stripe_customer_id: organization.stripe_customer_id,
-      external_id: organization.external_id,
-      metadata: organization.metadata,
-    };
+    context.organization = formatOrganization(organization, ws);
   }
 
   const membership = ws.organizationMemberships
@@ -312,11 +331,13 @@ export function buildJwtTemplateContext(
     .find((m) => m.user_id === user.id);
   if (membership) {
     context.organization_membership = {
+      object: 'organization_membership',
       id: membership.id,
       role: membership.role.slug,
       roles: [membership.role.slug],
-      external_id: membership.external_id,
-      metadata: membership.metadata,
+      created_at: membership.created_at,
+      updated_at: membership.updated_at,
+      custom_attributes: {},
     };
   }
 

--- a/src/workos/jwt-template.ts
+++ b/src/workos/jwt-template.ts
@@ -207,7 +207,18 @@ const PROBE_CONTEXT: JwtTemplateContext = {
   organization: {
     id: 'org_01PROBE',
     name: 'Probe Org',
-    domains: [{ domain: 'example.com' }],
+    domains: [
+      {
+        object: 'organization_domain',
+        id: 'org_domain_01PROBE',
+        organization_id: 'org_01PROBE',
+        domain: 'example.com',
+        state: 'verified',
+        verification_strategy: 'manual',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
     stripe_customer_id: null,
     external_id: null,
     metadata: {},
@@ -282,7 +293,16 @@ export function buildJwtTemplateContext(
       name: organization.name,
       domains: ws.organizationDomains
         .findBy('organization_id', organization.id)
-        .map((domain) => ({ id: domain.id, domain: domain.domain, state: domain.state })),
+        .map((domain) => ({
+          object: domain.object,
+          id: domain.id,
+          organization_id: domain.organization_id,
+          domain: domain.domain,
+          state: domain.state,
+          verification_strategy: domain.verification_strategy,
+          created_at: domain.created_at,
+          updated_at: domain.updated_at,
+        })),
       stripe_customer_id: organization.stripe_customer_id,
       external_id: organization.external_id,
       metadata: organization.metadata,

--- a/src/workos/jwt-template.ts
+++ b/src/workos/jwt-template.ts
@@ -291,18 +291,16 @@ export function buildJwtTemplateContext(
     context.organization = {
       id: organization.id,
       name: organization.name,
-      domains: ws.organizationDomains
-        .findBy('organization_id', organization.id)
-        .map((domain) => ({
-          object: domain.object,
-          id: domain.id,
-          organization_id: domain.organization_id,
-          domain: domain.domain,
-          state: domain.state,
-          verification_strategy: domain.verification_strategy,
-          created_at: domain.created_at,
-          updated_at: domain.updated_at,
-        })),
+      domains: ws.organizationDomains.findBy('organization_id', organization.id).map((domain) => ({
+        object: domain.object,
+        id: domain.id,
+        organization_id: domain.organization_id,
+        domain: domain.domain,
+        state: domain.state,
+        verification_strategy: domain.verification_strategy,
+        created_at: domain.created_at,
+        updated_at: domain.updated_at,
+      })),
       stripe_customer_id: organization.stripe_customer_id,
       external_id: organization.external_id,
       metadata: organization.metadata,

--- a/src/workos/response-shapes.spec.ts
+++ b/src/workos/response-shapes.spec.ts
@@ -72,6 +72,7 @@ const organization: WorkOSOrganization = {
   external_id: null,
   metadata: {},
   stripe_customer_id: null,
+  allow_profiles_outside_organization: false,
   created_at: TS,
   updated_at: TS,
 };

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -53,6 +53,7 @@ describe('Auth routes', () => {
       external_id: null,
       metadata: {},
       stripe_customer_id: null,
+      allow_profiles_outside_organization: false,
     });
   }
 

--- a/src/workos/routes/organizations.ts
+++ b/src/workos/routes/organizations.ts
@@ -20,6 +20,7 @@ export function organizationRoutes(ctx: RouteContext): void {
       external_id: (body.external_id as string) ?? null,
       metadata: (body.metadata as Record<string, string>) ?? {},
       stripe_customer_id: null,
+      allow_profiles_outside_organization: false,
     });
 
     const domainData = body.domain_data as Array<{ domain: string; state?: string }> | undefined;
@@ -103,6 +104,9 @@ export function organizationRoutes(ctx: RouteContext): void {
     }
     if ('external_id' in body) updates.external_id = body.external_id ?? null;
     if ('metadata' in body) updates.metadata = body.metadata ?? {};
+    if ('allow_profiles_outside_organization' in body) {
+      updates.allow_profiles_outside_organization = Boolean(body.allow_profiles_outside_organization);
+    }
 
     if ('domain_data' in body && Array.isArray(body.domain_data)) {
       const existing = ws.organizationDomains.findBy('organization_id', org.id);


### PR DESCRIPTION
- Render the full `organization_domain` (minus `verification_token`/`verification_prefix`) in the JWT template context instead of the three-field `{ id, domain, state }` subset.
- Mirror the full production API objects for `user`, `organization`, and `organization_membership` in the context, instead of the hand-picked subsets that dropped `object`, timestamps, and other fields production includes.
- Build the context from the existing `format*` helpers so it tracks the API response shape, then apply the adjustments prod's template context makes on top: add `user.identities` (an OAuth provider→null map for users with no linked identity) and drop `user.last_sign_in_at` and `organization.stripe_customer_id` when null.
- Fix `formatDomain` to stop leaking `verification_token`/`verification_prefix` into the organization API response (production omits them).
- Add `allow_profiles_outside_organization` to the organization entity and response.

The production context shapes were confirmed empirically by minting real AuthKit tokens with probe templates. `user.name` is intentionally not added here — it auto-inherits via `formatUser` once #43 lands.

Closes #37
