### PR TITLE
fix(users): include name field on user objects

### DIFF
--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -43,6 +43,7 @@ export interface WorkOSOrganizationMembership extends Entity {
 export interface WorkOSUser extends Entity {
   object: 'user';
   email: string;
+  name: string | null;
   first_name: string | null;
   last_name: string | null;
   email_verified: boolean;

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -105,6 +105,7 @@ export interface WorkOSSeedUser {
    */
   id?: string;
   email: string;
+  name?: string;
   first_name?: string;
   last_name?: string;
   password?: string;
@@ -272,6 +273,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: WorkOSSee
         object: 'user',
         id: userConfig.id,
         email: userConfig.email,
+        name: userConfig.name ?? null,
         first_name: userConfig.first_name ?? null,
         last_name: userConfig.last_name ?? null,
         email_verified: userConfig.email_verified ?? false,

--- a/src/workos/response-shapes.spec.ts
+++ b/src/workos/response-shapes.spec.ts
@@ -51,6 +51,7 @@ const user: WorkOSUser = {
   id: 'user_01',
   object: 'user',
   email: 'alice@example.com',
+  name: 'Alice Smith',
   first_name: 'Alice',
   last_name: 'Smith',
   email_verified: true,

--- a/src/workos/routes/auth-challenges.spec.ts
+++ b/src/workos/routes/auth-challenges.spec.ts
@@ -28,6 +28,7 @@ describe('Auth challenge routes', () => {
     const ws = getWorkOSStore(store);
     const user = ws.users.insert({
       object: 'user',
+      name: null,
       email: 'mfa@test.com',
       first_name: null,
       last_name: null,

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -32,6 +32,7 @@ describe('Auth routes', () => {
     const ws = getWorkOSStore(store);
     return ws.users.insert({
       object: 'user',
+      name: null,
       email,
       first_name: null,
       last_name: null,
@@ -199,6 +200,7 @@ describe('Auth routes', () => {
     const ws = getWorkOSStore(store);
     ws.users.insert({
       object: 'user',
+      name: null,
       email: 'msft@test.com',
       first_name: null,
       last_name: null,
@@ -1154,6 +1156,7 @@ describe('AuthKit interactive auth', () => {
     const ws = getWorkOSStore(store);
     ws.users.insert({
       object: 'user',
+      name: null,
       email: 'alice@test.com',
       first_name: null,
       last_name: null,
@@ -1188,6 +1191,7 @@ describe('AuthKit interactive auth', () => {
     const ws = getWorkOSStore(store);
     ws.users.insert({
       object: 'user',
+      name: null,
       email: 'post@test.com',
       first_name: null,
       last_name: null,
@@ -1223,6 +1227,7 @@ describe('AuthKit interactive auth', () => {
     const ws = getWorkOSStore(store);
     ws.users.insert({
       object: 'user',
+      name: null,
       email: 'e2e@test.com',
       first_name: null,
       last_name: null,

--- a/src/workos/routes/sessions.spec.ts
+++ b/src/workos/routes/sessions.spec.ts
@@ -26,6 +26,7 @@ describe('Session routes', () => {
     const ws = getWorkOSStore(store);
     const user = ws.users.insert({
       object: 'user',
+      name: null,
       email: 'logout@test.com',
       first_name: null,
       last_name: null,
@@ -64,6 +65,7 @@ describe('Session routes', () => {
     const ws = getWorkOSStore(store);
     const user = ws.users.insert({
       object: 'user',
+      name: null,
       email: 'logout2@test.com',
       first_name: null,
       last_name: null,

--- a/src/workos/routes/users.spec.ts
+++ b/src/workos/routes/users.spec.ts
@@ -106,6 +106,73 @@ describe('User routes', () => {
   });
 });
 
+describe('User name field', () => {
+  let app: ReturnType<typeof createTestApp>['app'];
+
+  beforeEach(() => {
+    app = createTestApp().app;
+  });
+
+  const req = (path: string, init?: RequestInit) => app.request(path, { headers, ...init });
+  const json = (res: Response) => res.json() as Promise<any>;
+
+  it('creates a user with name and returns it', async () => {
+    const res = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'named@test.com', name: 'Alice Smith' }),
+    });
+    expect(res.status).toBe(201);
+    const user = await json(res);
+    expect(user.name).toBe('Alice Smith');
+  });
+
+  it('creates a user without name and returns null', async () => {
+    const res = await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'noname@test.com' }),
+    });
+    expect(res.status).toBe(201);
+    const user = await json(res);
+    expect(user.name).toBeNull();
+  });
+
+  it('updates a user name via PUT', async () => {
+    const created = await json(
+      await req('/user_management/users', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'updatename@test.com' }),
+      }),
+    );
+    expect(created.name).toBeNull();
+
+    const res = await req(`/user_management/users/${created.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'Bob Jones' }),
+    });
+    expect(res.status).toBe(200);
+    expect((await json(res)).name).toBe('Bob Jones');
+  });
+
+  it('leaves name unchanged when omitted from update', async () => {
+    const created = await json(
+      await req('/user_management/users', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'keepname@test.com', name: 'Carol Lee' }),
+      }),
+    );
+    expect(created.name).toBe('Carol Lee');
+
+    const res = await req(`/user_management/users/${created.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({ first_name: 'Carol' }),
+    });
+    expect(res.status).toBe(200);
+    const updated = await json(res);
+    expect(updated.name).toBe('Carol Lee');
+    expect(updated.first_name).toBe('Carol');
+  });
+});
+
 describe('Email Verification', () => {
   let app: ReturnType<typeof createTestApp>['app'];
 

--- a/src/workos/routes/users.ts
+++ b/src/workos/routes/users.ts
@@ -29,6 +29,7 @@ export function userRoutes(ctx: RouteContext): void {
     const user = ws.users.insert({
       object: 'user',
       email,
+      name: (body.name as string) ?? null,
       first_name: (body.first_name as string) ?? null,
       last_name: (body.last_name as string) ?? null,
       email_verified: (body.email_verified as boolean) ?? false,
@@ -86,6 +87,7 @@ export function userRoutes(ctx: RouteContext): void {
     const body = await parseJsonBody(c);
     const updates: Record<string, unknown> = {};
 
+    if ('name' in body) updates.name = body.name ?? null;
     if ('first_name' in body) updates.first_name = body.first_name ?? null;
     if ('last_name' in body) updates.last_name = body.last_name ?? null;
     if ('email_verified' in body) updates.email_verified = body.email_verified;

--- a/src/workos/routes/users.ts
+++ b/src/workos/routes/users.ts
@@ -25,11 +25,15 @@ export function userRoutes(ctx: RouteContext): void {
       throw new WorkOSApiError(409, 'A user with this email already exists', 'user_already_exists');
     }
 
+    if (body.name !== undefined && body.name !== null && typeof body.name !== 'string') {
+      throw validationError('name must be a string or null', [{ field: 'name', code: 'invalid_type' }]);
+    }
+
     const password = body.password as string | undefined;
     const user = ws.users.insert({
       object: 'user',
       email,
-      name: typeof body.name === 'string' ? body.name : null,
+      name: (body.name as string | null) ?? null,
       first_name: (body.first_name as string) ?? null,
       last_name: (body.last_name as string) ?? null,
       email_verified: (body.email_verified as boolean) ?? false,
@@ -87,7 +91,12 @@ export function userRoutes(ctx: RouteContext): void {
     const body = await parseJsonBody(c);
     const updates: Record<string, unknown> = {};
 
-    if ('name' in body) updates.name = typeof body.name === 'string' ? body.name : null;
+    if ('name' in body) {
+      if (typeof body.name !== 'string' && body.name !== null) {
+        throw validationError('name must be a string or null', [{ field: 'name', code: 'invalid_type' }]);
+      }
+      updates.name = body.name;
+    }
     if ('first_name' in body) updates.first_name = body.first_name ?? null;
     if ('last_name' in body) updates.last_name = body.last_name ?? null;
     if ('email_verified' in body) updates.email_verified = body.email_verified;

--- a/src/workos/routes/users.ts
+++ b/src/workos/routes/users.ts
@@ -29,7 +29,7 @@ export function userRoutes(ctx: RouteContext): void {
     const user = ws.users.insert({
       object: 'user',
       email,
-      name: (body.name as string) ?? null,
+      name: typeof body.name === 'string' ? body.name : null,
       first_name: (body.first_name as string) ?? null,
       last_name: (body.last_name as string) ?? null,
       email_verified: (body.email_verified as boolean) ?? false,
@@ -87,7 +87,7 @@ export function userRoutes(ctx: RouteContext): void {
     const body = await parseJsonBody(c);
     const updates: Record<string, unknown> = {};
 
-    if ('name' in body) updates.name = body.name ?? null;
+    if ('name' in body) updates.name = typeof body.name === 'string' ? body.name : null;
     if ('first_name' in body) updates.first_name = body.first_name ?? null;
     if ('last_name' in body) updates.last_name = body.last_name ?? null;
     if ('email_verified' in body) updates.email_verified = body.email_verified;


### PR DESCRIPTION
- Add `name` to the `WorkOSUser` entity and accept it in the create/update handlers; `formatUser` propagates it automatically.
- The emulator previously dropped `name` on write and never returned it, so SDK consumers reading `User.name` saw `null` forever and name-gated flows couldn't pass.
- Matches the OpenAPI spec and `@workos-inc/node`, which treat `name` as an independently stored, nullable field.

Closes #34
