### PR TITLE
fix(auth): add jti claim to AuthKit access tokens

### DIFF
--- a/src/workos/jwt-template-integration.spec.ts
+++ b/src/workos/jwt-template-integration.spec.ts
@@ -169,6 +169,7 @@ describe('JWT templates end to end', () => {
       'exp',
       'iat',
       'iss',
+      'jti',
       'org_id',
       'permissions',
       'role',

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -542,10 +542,22 @@ describe('Auth routes', () => {
     expect(claims.org_id).toBe(org.id);
     expect(claims.role).toBe('admin');
     expect(claims.roles).toEqual(['admin']);
+    // AuthKit access tokens carry a ULID jti, matching production and the M2M path.
+    expect(claims.jti).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
 
     // The session records the same organization the token claims.
     const session = getWorkOSStore(store).sessions.get(claims.sid);
     expect(session?.organization_id).toBe(org.id);
+  });
+
+  it('gives each AuthKit access token a distinct jti', async () => {
+    await createUser('jti-a@test.com');
+    await createUser('jti-b@test.com');
+    const first = decodeJwt((await json(await signInWithMagicAuth('jti-a@test.com'))).access_token);
+    const second = decodeJwt((await json(await signInWithMagicAuth('jti-b@test.com'))).access_token);
+    expect(first.jti).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(second.jti).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(first.jti).not.toBe(second.jti);
   });
 
   it('resolves the single active organization through the AuthKit hosted flow', async () => {

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { type RouteContext, notFound, parseJsonBody, WorkOSApiError, generateId } from '../../core/index.js';
+import { type RouteContext, notFound, parseJsonBody, WorkOSApiError, generateId, generateUlid } from '../../core/index.js';
 import { getWorkOSStore } from '../store.js';
 import {
   formatUser,
@@ -701,6 +701,7 @@ export function authRoutes(ctx: RouteContext): void {
       {
         sub: user.id,
         sid: session.id,
+        jti: generateUlid(),
         org_id: organizationId ?? undefined,
         role: roleSlug,
         // Production emits the plural `roles` alongside `role`; the emulator models one role per

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -1,5 +1,12 @@
 import { createHash } from 'node:crypto';
-import { type RouteContext, notFound, parseJsonBody, WorkOSApiError, generateId, generateUlid } from '../../core/index.js';
+import {
+  type RouteContext,
+  notFound,
+  parseJsonBody,
+  WorkOSApiError,
+  generateId,
+  generateUlid,
+} from '../../core/index.js';
 import { getWorkOSStore } from '../store.js';
 import {
   formatUser,


### PR DESCRIPTION
- Add `jti: generateUlid()` to the AuthKit access-token mint site, matching the existing M2M token behavior.
- Real AuthKit tokens include `jti`; the emulator omitted it, so consumers validating a strict token contract (requiring `jti`) failed against the emulator.
- `JWTClaims.jti` was already declared; only the mint site and a test change.

Closes #39
