### PR TITLE
ci(docker): publish and verify an arm64 GHCR image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,29 @@ jobs:
           # connection-refused (curl 7). The container is created before the
           # Node app finishes binding :4100, so the first probe can hit a RST.
           curl --retry 10 --retry-delay 1 --retry-all-errors --fail http://localhost:4100/health
+
+  docker-arm64:
+    name: Docker build (arm64)
+    # Native ARM runner — builds the arm64 image the release workflow publishes
+    # to GHCR, without QEMU emulation. Mirrors `docker` above on ubuntu-24.04-arm
+    # (the same runner the standalone-binary smoke tests use for arm64).
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          push: false
+          load: true
+          tags: emulate:ci
+
+      - name: Container smoke test
+        shell: bash
+        run: |
+          docker run --rm -d -p 4100:4100 --name emulate-ci emulate:ci
+          trap 'docker stop emulate-ci 2>/dev/null || true' EXIT
+          # `--retry-all-errors` retries on TCP reset (curl 56) too, not just
+          # connection-refused (curl 7). The container is created before the
+          # Node app finishes binding :4100, so the first probe can hit a RST.
+          curl --retry 10 --retry-delay 1 --retry-all-errors --fail http://localhost:4100/health

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,9 +272,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # QEMU + Buildx let a single amd64 runner build and push a multi-arch
+      # manifest list (amd64 + arm64) so ARM hosts pull a native image. The
+      # Dockerfile's base images (oven/bun, node:22-alpine) are already
+      # multi-arch, so no Dockerfile changes are needed.
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
 


### PR DESCRIPTION
## Summary

The container image published to GHCR (`ghcr.io/workos/emulate`) was `linux/amd64` only, so ARM hosts had no native image to pull. Closes #61, which reports testing running entirely on ARM machines.

## Changes

- **Release (`release.yml`, `publish-ghcr`):** build and push a multi-arch manifest list (`linux/amd64,linux/arm64`) using `docker/setup-qemu-action` + `docker/setup-buildx-action`, so ARM hosts automatically pull a native arm64 variant under the existing tags (`:version`, `:latest`/`:beta`, `:sha-<short>`). No `Dockerfile` changes were needed — its base images (`oven/bun:1.3.14`, `node:22-alpine`) are already multi-arch.
- **CI (`ci.yml`):** add an additive `docker-arm64` job on the native `ubuntu-24.04-arm` runner that builds the image and runs the `/health` container smoke test, mirroring the existing amd64 `docker` job. This gates the published arm64 image on every PR instead of only at release time.

## Verification

- `actionlint` passes clean on both `ci.yml` and `release.yml`.
- Built the image for `--platform linux/arm64` on Apple Silicon and ran the container: `curl /health` returns `{"status":"ok"}`; image confirmed `arm64/linux`.

The actual multi-arch push is only exercised by the release workflow on a tag, but the arm64 Dockerfile build + runtime smoke test on real arm64 hardware covers the part that could break.
