### PR TITLE
fix(auth): gate the password grant on email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,30 @@ curl -X POST http://localhost:4100/user_management/authenticate \
 
 Only `active` memberships count — an unaccepted invitation or a deactivated member is never selected. Passing `invitation_token` to the `authorization_code`, `password`, or Magic Auth grants accepts the invitation as part of the login, joining the user to the invited organization and scoping the session to it, so there is no selection step; a token that is unknown, expired, or already used is rejected with `invitation_invalid`, and one addressed to somebody else with `invitation_cannot_be_used_for_email`. Once a session exists, only an explicit `organization_id` on a refresh (`switchToOrganization`) moves it between organizations.
 
+### Email verification gates the password grant
+
+A password sign-in by a user whose `email_verified` is `false` does not return a session. Production answers `email_verification_required`, and that response is what sends the user to a verification screen — so the emulator does too:
+
+```json
+{
+  "code": "email_verification_required",
+  "message": "Email ownership must be verified before authentication.",
+  "pending_authentication_token": "pending_...",
+  "email_verification_id": "email_verification_...",
+  "email": "bob@example.com"
+}
+```
+
+The gate creates an email verification, so the code arrives on the `email_verification.created` webhook like every other emailed code. Finish the sign-in with the token and the code — exactly what the SDKs' `authenticateWithEmailVerification` sends:
+
+```bash
+curl -X POST http://localhost:4100/user_management/authenticate \
+  -H "Content-Type: application/json" \
+  -d '{"grant_type":"urn:workos:oauth:grant-type:email-verification:code","pending_authentication_token":"pending_...","code":"123456"}'
+```
+
+The resulting session records the method that was gated (`password`), not the verification step. Driving the grant with `user_id` instead of a pending token still works, and that session reports `unknown` — there is no primary method to recover. Fixtures that sign in with a password want `email_verified: true`, in a seed file or on `POST /user_management/users`.
+
 ### Refresh tokens always rotate
 
 The emulator issues a new refresh token on every refresh and invalidates the one you presented, so replaying it returns `{"error": "invalid_grant", "error_description": "Invalid refresh token."}`. WorkOS documents that refresh tokens _may_ be rotated after use, so production is free to hand back the same token and leave it valid. The emulator always takes the stricter path: a client that forgets to store the newly returned `refresh_token` fails locally instead of in production.

--- a/scripts/smoke-node.mjs
+++ b/scripts/smoke-node.mjs
@@ -51,6 +51,8 @@ try {
       password: 'correct horse battery staple',
       first_name: 'Node',
       last_name: 'Compatibility',
+      // The password grant gates an unverified mailbox with email_verification_required.
+      email_verified: true,
     }),
   });
   assert.equal(userResponse.status, 201);

--- a/src/e2e.spec.ts
+++ b/src/e2e.spec.ts
@@ -139,7 +139,12 @@ describe('end-to-end login flow (workos.com/docs story)', () => {
 
     const res = await api('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email, password: 'correct horse battery staple', first_name: 'Alice' }),
+      body: JSON.stringify({
+        email,
+        password: 'correct horse battery staple',
+        first_name: 'Alice',
+        email_verified: true,
+      }),
     });
     expect(res.status).toBe(201);
     userId = ((await res.json()) as any).id;

--- a/src/workos/concurrent-webhooks.spec.ts
+++ b/src/workos/concurrent-webhooks.spec.ts
@@ -264,6 +264,7 @@ describe('Concurrent Webhook Delivery', () => {
       body: JSON.stringify({
         email: 'auth1@example.com',
         password: 'password123',
+        email_verified: true,
       }),
     });
     await user1Res.json();
@@ -277,6 +278,7 @@ describe('Concurrent Webhook Delivery', () => {
       body: JSON.stringify({
         email: 'auth2@example.com',
         password: 'password123',
+        email_verified: true,
       }),
     });
     await user2Res.json();

--- a/src/workos/jwt-template-integration.spec.ts
+++ b/src/workos/jwt-template-integration.spec.ts
@@ -18,7 +18,9 @@ describe('JWT templates end to end', () => {
   });
 
   const seed = {
-    users: [{ email: 'alice@acme.com', first_name: 'Alice', last_name: 'Smith', password: 'test123' }],
+    users: [
+      { email: 'alice@acme.com', first_name: 'Alice', last_name: 'Smith', password: 'test123', email_verified: true },
+    ],
     organizations: [
       {
         name: 'Acme Corp',
@@ -66,7 +68,7 @@ describe('JWT templates end to end', () => {
     const claims = decode(body.access_token);
     expect(claims['urn:myapp:name']).toBe('Alice Smith');
     expect(claims['urn:myapp:tenant']).toBe('tenant_123');
-    expect(claims['urn:myapp:verified']).toBe(false);
+    expect(claims['urn:myapp:verified']).toBe(true);
     // The claims the emulator resolves are still there.
     expect(claims.sub).toBeString();
     expect(claims.role).toBe('admin');
@@ -131,7 +133,7 @@ describe('JWT templates end to end', () => {
       // Valid against the probe values, but renders past the byte limit for this user.
       seed: {
         ...seed,
-        users: [{ email: 'alice@acme.com', first_name: 'x'.repeat(4000), password: 'test123' }],
+        users: [{ email: 'alice@acme.com', first_name: 'x'.repeat(4000), password: 'test123', email_verified: true }],
         jwtTemplate: { content: '{"urn:myapp:name": "{{ user.first_name }}"}' },
       },
     });
@@ -149,7 +151,7 @@ describe('JWT templates end to end', () => {
       port: 0,
       seed: {
         ...seed,
-        users: [{ email: 'alice@acme.com', first_name: 'x'.repeat(4000), password: 'test123' }],
+        users: [{ email: 'alice@acme.com', first_name: 'x'.repeat(4000), password: 'test123', email_verified: true }],
         jwtTemplate: { content: '{"urn:myapp:name": "{{ user.first_name }}"}' },
       },
     });
@@ -235,7 +237,7 @@ describe('JWT templates end to end', () => {
       expect(u.email).toBe('alice@acme.com');
       expect(u.first_name).toBe('Alice');
       expect(u.last_name).toBe('Smith');
-      expect(u.email_verified).toBe(false);
+      expect(u.email_verified).toBe(true);
       expect(u.profile_picture_url).toBeNull();
       expect(u.created_at).toBeString();
       expect(u.updated_at).toBeString();
@@ -379,7 +381,7 @@ describe('Pinned signing key and issuer', () => {
     emulator = await createEmulator({
       port: 0,
       issuer: 'https://api.workos.com',
-      seed: { users: [{ email: 'alice@acme.com', password: 'test123' }] },
+      seed: { users: [{ email: 'alice@acme.com', password: 'test123', email_verified: true }] },
     });
 
     const res = await fetch(`${emulator.url}/user_management/authenticate`, {
@@ -401,7 +403,7 @@ describe('Pinned signing key and issuer', () => {
   it('defaults the issuer to the emulator URL', async () => {
     emulator = await createEmulator({
       port: 0,
-      seed: { users: [{ email: 'alice@acme.com', password: 'test123' }] },
+      seed: { users: [{ email: 'alice@acme.com', password: 'test123', email_verified: true }] },
     });
 
     const res = await fetch(`${emulator.url}/user_management/authenticate`, {

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -26,9 +26,12 @@ describe('Auth routes', () => {
   const req = (path: string, init?: RequestInit) => app.request(path, { headers, ...init });
   const json = (res: Response) => res.json() as Promise<any>;
 
+  // Verified by default: the password grant gates an unverified mailbox with
+  // email_verification_required, so a fixture for anything other than that gate is a user who
+  // has already been through it.
   async function createUser(
     email: string,
-    opts?: { password?: string; impersonator?: { email: string; reason: string } },
+    opts?: { password?: string; impersonator?: { email: string; reason: string }; email_verified?: boolean },
   ) {
     const ws = getWorkOSStore(store);
     return ws.users.insert({
@@ -37,7 +40,7 @@ describe('Auth routes', () => {
       email,
       first_name: null,
       last_name: null,
-      email_verified: false,
+      email_verified: opts?.email_verified ?? true,
       profile_picture_url: null,
       last_sign_in_at: null,
       external_id: null,
@@ -162,7 +165,7 @@ describe('Auth routes', () => {
   it('authenticate with password grant', async () => {
     await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'pass@test.com', password: 'secret' }),
+      body: JSON.stringify({ email: 'pass@test.com', password: 'secret', email_verified: true }),
     });
 
     const res = await app.request('/user_management/authenticate', {
@@ -184,7 +187,7 @@ describe('Auth routes', () => {
   it('rejects invalid password', async () => {
     await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'bad@test.com', password: 'correct' }),
+      body: JSON.stringify({ email: 'bad@test.com', password: 'correct', email_verified: true }),
     });
 
     const res = await app.request('/user_management/authenticate', {
@@ -200,6 +203,109 @@ describe('Auth routes', () => {
     expect(await json(res)).toEqual({
       code: 'invalid_credentials',
       message: "Invalid credentials for 'bad@test.com'.",
+    });
+  });
+
+  describe('email verification gate', () => {
+    const post = (body: unknown) =>
+      app.request('/user_management/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    /** Sign up unverified and take the password grant's 403 to the verification step. */
+    async function gatedSignIn(email: string, extra?: Record<string, unknown>) {
+      const user = await json(
+        await req('/user_management/users', { method: 'POST', body: JSON.stringify({ email, password: 'pw' }) }),
+      );
+      const res = await post({ grant_type: 'password', email, password: 'pw', ...extra });
+      return { user, res, body: await json(res) };
+    }
+
+    it('refuses an unverified password sign-in with email_verification_required', async () => {
+      const { user, res, body } = await gatedSignIn('unverified@test.com');
+
+      expect(res.status).toBe(403);
+      expect(body).toMatchObject({
+        code: 'email_verification_required',
+        pending_authentication_token: expect.any(String),
+        email_verification_id: expect.any(String),
+        email: 'unverified@test.com',
+      });
+      // No session, and the user is still unverified: the gate is not a login.
+      expect(getWorkOSStore(store).sessions.findBy('user_id', user.id)).toHaveLength(0);
+      expect((await json(await req(`/user_management/users/${user.id}`))).email_verified).toBe(false);
+    });
+
+    it('redeems the pending token with the code the SDK sends, keying the session to password', async () => {
+      const { user, body } = await gatedSignIn('verify-me@test.com');
+      const verification = await json(await req(`/user_management/email_verification/${body.email_verification_id}`));
+
+      // Exactly what serializeAuthenticateWithEmailVerificationOptions sends: no user_id.
+      const res = await post({
+        grant_type: 'urn:workos:oauth:grant-type:email-verification:code',
+        pending_authentication_token: body.pending_authentication_token,
+        code: verification.code,
+      });
+
+      expect(res.status).toBe(200);
+      const authenticated = await json(res);
+      expect(authenticated.access_token).toBeDefined();
+      expect(authenticated.user.email_verified).toBe(true);
+      const [session] = getWorkOSStore(store).sessions.findBy('user_id', user.id);
+      expect(session.auth_method).toBe('password');
+
+      // The token is one-time: a replay finds nothing to resolve the user from.
+      const replay = await post({
+        grant_type: 'urn:workos:oauth:grant-type:email-verification:code',
+        pending_authentication_token: body.pending_authentication_token,
+        code: verification.code,
+      });
+      expect(replay.status).toBe(400);
+      expect((await json(replay)).code).toBe('invalid_pending_authentication_token');
+    });
+
+    it('carries an invitation across the gate', async () => {
+      const org = createOrg('Gated Corp');
+      const invitation = await invite('invited@test.com', org.id, 'admin');
+      const { user, body } = await gatedSignIn('invited@test.com', { invitation_token: invitation.token });
+
+      // Not spent by the gate — the client may never come back from a 403.
+      expect((await readInvitation(invitation.token)).state).toBe('pending');
+
+      const verification = await json(await req(`/user_management/email_verification/${body.email_verification_id}`));
+      const res = await post({
+        grant_type: 'urn:workos:oauth:grant-type:email-verification:code',
+        pending_authentication_token: body.pending_authentication_token,
+        code: verification.code,
+      });
+
+      expect(res.status).toBe(200);
+      expect((await json(res)).organization_id).toBe(org.id);
+      expect((await readInvitation(invitation.token)).state).toBe('accepted');
+      expect((await membershipsIn(org.id)).map((m: any) => m.user_id)).toEqual([user.id]);
+    });
+
+    it('still accepts user_id, and names both ways in when neither is sent', async () => {
+      const user = await createUser('by-id@test.com', { email_verified: false });
+      const verification = await json(
+        await req(`/user_management/users/${user.id}/email_verification/send`, { method: 'POST' }),
+      );
+
+      const missing = await post({ grant_type: 'urn:workos:oauth:grant-type:email-verification:code', code: '123456' });
+      expect(missing.status).toBe(400);
+      expect(await json(missing)).toEqual({
+        error: 'invalid_request',
+        error_description: 'code and pending_authentication_token (or user_id) are required.',
+      });
+
+      const res = await post({
+        grant_type: 'urn:workos:oauth:grant-type:email-verification:code',
+        user_id: user.id,
+        code: verification.code,
+      });
+      expect(res.status).toBe(200);
     });
   });
 
@@ -331,7 +437,7 @@ describe('Auth routes', () => {
   it('refresh_token grant returns new tokens and invalidates old', async () => {
     await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'refresh@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'refresh@test.com', password: 'pw', email_verified: true }),
     });
 
     // Authenticate to get a refresh token
@@ -738,7 +844,7 @@ describe('Auth routes', () => {
   it('returns sealed_session when client_secret provided', async () => {
     await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'sealed@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'sealed@test.com', password: 'pw', email_verified: true }),
     });
 
     const res = await app.request('/user_management/authenticate', {
@@ -834,7 +940,7 @@ describe('Auth routes', () => {
     );
     expect(signup.email).toBe('padded@x.test');
 
-    getWorkOSStore(store).users.update(signup.user_id, { password_hash: hashPassword('pw') });
+    getWorkOSStore(store).users.update(signup.user_id, { password_hash: hashPassword('pw'), email_verified: true });
     const password = await app.request('/user_management/authenticate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -952,7 +1058,7 @@ describe('Auth routes', () => {
   it('reaches a Magic Auth account by any casing of its address', async () => {
     await req('/user_management/magic_auth', { method: 'POST', body: JSON.stringify({ email: 'Mixed@Case.test' }) });
     const user = getWorkOSStore(store).users.all()[0];
-    getWorkOSStore(store).users.update(user.id, { password_hash: hashPassword('correct horse') });
+    getWorkOSStore(store).users.update(user.id, { password_hash: hashPassword('correct horse'), email_verified: true });
 
     const password = await app.request('/user_management/authenticate', {
       method: 'POST',
@@ -1083,7 +1189,7 @@ describe('Auth routes', () => {
   it('password grant accepts form-encoded bodies', async () => {
     await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'formpass@test.com', password: 'secret' }),
+      body: JSON.stringify({ email: 'formpass@test.com', password: 'secret', email_verified: true }),
     });
 
     const res = await app.request('/user_management/authenticate', {
@@ -1517,7 +1623,7 @@ describe('Auth routes', () => {
   it('resolves the single active organization on password, email-verification and device_code', async () => {
     const created = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'multi-grant@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'multi-grant@test.com', password: 'pw', email_verified: true }),
     });
     const user = await json(created);
     const org = joinOrg(user.id, 'Grant Corp');
@@ -1567,7 +1673,7 @@ describe('Auth routes', () => {
   it('returns organization_selection_required for a user with several active organizations', async () => {
     const created = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'multi-org@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'multi-org@test.com', password: 'pw', email_verified: true }),
     });
     const user = await json(created);
     const first = joinOrg(user.id, 'Alpha Corp');
@@ -1614,7 +1720,7 @@ describe('Auth routes', () => {
   it('requires the second factor before organization selection', async () => {
     const created = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'mfa-multi-org@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'mfa-multi-org@test.com', password: 'pw', email_verified: true }),
     });
     const user = await json(created);
     joinOrg(user.id, 'Gamma Corp');
@@ -1859,7 +1965,7 @@ describe('Auth routes', () => {
   it('holds an invitation until the second factor clears', async () => {
     const created = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'mfa-invite@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'mfa-invite@test.com', password: 'pw', email_verified: true }),
     });
     const user = await json(created);
     const org = createOrg('Second Factor Corp');
@@ -1907,7 +2013,7 @@ describe('Auth routes', () => {
   it('reports the same error when a deferred invitation dies mid-challenge', async () => {
     const created = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'mfa-revoked@test.com', password: 'pw' }),
+      body: JSON.stringify({ email: 'mfa-revoked@test.com', password: 'pw', email_verified: true }),
     });
     const user = await json(created);
     const org = createOrg('Vanishing Corp');
@@ -2228,7 +2334,7 @@ describe('authentication events (spec-named, spec-shaped)', () => {
   async function registerUser(email: string, password: string) {
     const res = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email, password, email_verified: true }),
     });
     return json(res);
   }

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -311,6 +311,48 @@ export function authRoutes(ctx: RouteContext): void {
       );
     };
 
+    /**
+     * Gate a sign-in whose credential proves nothing about the mailbox. Production answers an
+     * unverified user with `email_verification_required` instead of a session, and that response
+     * is what sends them to a verification screen. A fresh email_verification is created, so the
+     * code reaches a test the way every other emulator flow delivers one — on the
+     * `email_verification.created` webhook — and the pending token carries the primary method
+     * (so the eventual session reports it rather than 'unknown') plus any still-unspent
+     * invitation, on the same deferral rule the MFA challenge uses.
+     */
+    const issueEmailVerification = (
+      unverified: { id: string; email: string },
+      orgId: string | null,
+      primaryMethod: string,
+    ) => {
+      const pendingToken = generateId('pending');
+      store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, {
+        user_id: unverified.id,
+        organization_id: orgId,
+        auth_method: primaryMethod,
+        invitation_token: invitation?.token ?? null,
+      });
+      const verification = ws.emailVerifications.insert({
+        object: 'email_verification',
+        user_id: unverified.id,
+        email: unverified.email,
+        code: generateCode(),
+        expires_at: expiresIn(10),
+      });
+      // 403 with {code, message}, like mfa_challenge and organization_selection_required: the
+      // spec lists all three as authenticate's step-up codes under 403, never under its 400.
+      return c.json(
+        {
+          code: 'email_verification_required',
+          message: 'Email ownership must be verified before authentication.',
+          pending_authentication_token: pendingToken,
+          email_verification_id: verification.id,
+          email: unverified.email,
+        },
+        403,
+      );
+    };
+
     let user;
     let organizationId: string | null = null;
     let authMethod: string;
@@ -426,6 +468,13 @@ export function authRoutes(ctx: RouteContext): void {
         }
         authMethod = 'Password';
 
+        // Checked before the factor challenge below: an unverified mailbox is the earlier gate,
+        // and challenging a second factor for an account whose first contact detail is unproven
+        // would hand out a challenge production never issues.
+        if (!user.email_verified) {
+          return issueEmailVerification(user, organizationId, 'Password');
+        }
+
         // A user with enrolled factors must clear a second factor before a session is issued:
         // hand back a pending token (recording 'Password' as the primary method) and a challenge.
         const passwordFactors = ws.authFactors.findBy('user_id', user.id);
@@ -470,9 +519,29 @@ export function authRoutes(ctx: RouteContext): void {
       case 'urn:workos:oauth:grant-type:email-verification':
       case 'urn:workos:oauth:grant-type:email-verification:code': {
         const code = body.code as string;
-        const userId = body.user_id as string;
+        // The SDKs send `pending_authentication_token` and nothing else identifying the user
+        // (`serializeAuthenticateWithEmailVerificationOptions` in @workos-inc/node), which is the
+        // token the password grant's gate above hands out. `user_id` stays accepted for callers
+        // already driving this grant the emulator's old way.
+        const pendingToken = body.pending_authentication_token as string | undefined;
+        let pending: PendingAuth | undefined;
+        if (pendingToken) {
+          pending = store.getData<PendingAuth>(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`);
+          if (!pending) {
+            throw new WorkOSApiError(
+              400,
+              'Invalid pending authentication token',
+              'invalid_pending_authentication_token',
+            );
+          }
+        }
+        const userId = pending?.user_id ?? (body.user_id as string);
         if (!code || !userId) {
-          throw new OauthApiError(400, 'invalid_request', 'code and user_id are required.');
+          throw new OauthApiError(
+            400,
+            'invalid_request',
+            'code and pending_authentication_token (or user_id) are required.',
+          );
         }
 
         const ev = ws.emailVerifications.findBy('user_id', userId).find((v) => v.code === code);
@@ -491,10 +560,25 @@ export function authRoutes(ctx: RouteContext): void {
           );
         }
 
+        // Revalidated before the pending token is consumed, on the same rule the MFA grant
+        // states: an invitation revoked mid-flow fails the request without destroying the state
+        // behind it, so a retry still reports invitation_invalid.
+        const deferredInvitation = pending?.invitation_token ? resolveInvitation(pending.invitation_token) : null;
+
         ws.users.update(userId, { email_verified: true });
         ws.emailVerifications.delete(ev.id);
+        if (pendingToken) store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, undefined);
         user = ws.users.get(userId);
+        if (pending) {
+          organizationId = pending.organization_id;
+          invitation = deferredInvitation;
+        }
+        // Event is authentication.email_verification_succeeded; the session records the method
+        // that was gated (e.g. 'password'), since verification is a gate rather than a way to
+        // sign in. Without a pending token there is nothing to record, and the session falls
+        // back to 'unknown' as before.
         authMethod = 'EmailVerification';
+        sessionAuthMethod = pending?.auth_method;
         break;
       }
 

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -569,10 +569,8 @@ export function authRoutes(ctx: RouteContext): void {
         ws.emailVerifications.delete(ev.id);
         if (pendingToken) store.setData(`${STORE_KEY_PREFIXES.pendingAuth}${pendingToken}`, undefined);
         user = ws.users.get(userId);
-        if (pending) {
-          organizationId = pending.organization_id;
-          invitation = deferredInvitation;
-        }
+        organizationId = pending?.organization_id ?? null;
+        invitation = deferredInvitation;
         // Event is authentication.email_verification_succeeded; the session records the method
         // that was gated (e.g. 'password'), since verification is a gate rather than a way to
         // sign in. Without a pending token there is nothing to record, and the session falls

--- a/src/workos/routes/password-reset.spec.ts
+++ b/src/workos/routes/password-reset.spec.ts
@@ -33,7 +33,7 @@ describe('Password reset routes', () => {
     const user = await json(
       await req('/user_management/users', {
         method: 'POST',
-        body: JSON.stringify({ email: 'reset@test.com', password: 'oldpassword' }),
+        body: JSON.stringify({ email: 'reset@test.com', password: 'oldpassword', email_verified: true }),
       }),
     );
     const reset = await json(


### PR DESCRIPTION
Fixes #68.

Two independent bugs that together made the sign up → verify journey impossible to exercise: nothing issued a pending token, and nothing would have redeemed one.

## 1. The password grant never checked `email_verified`

An unverified user was signed straight in. It now answers the spec's `email_verification_required`:

```json
{
  "code": "email_verification_required",
  "message": "Email ownership must be verified before authentication.",
  "pending_authentication_token": "pending_...",
  "email_verification_id": "email_verification_...",
  "email": "bob@acme.test"
}
```

**403, not the 400 the issue reports.** The spec puts `email_verification_required` under authenticate's 403 alongside `mfa_challenge` and `organization_selection_required` — the two step-ups the emulator already answers that way — and never under its 400. The Node SDK dispatches on `code`, not status, so `EmailVerificationRequiredException` is raised either way. Happy to flip it if you've measured 400 in production.

The gate creates an `email_verification`, so the code reaches a test on the `email_verification.created` webhook like every other emailed code. It is checked before the MFA factor challenge: an unproven mailbox is the earlier gate.

## 2. The verification grant expected `user_id`

It now accepts `pending_authentication_token`, exactly as `serializeAuthenticateWithEmailVerificationOptions` sends it. `user_id` still works for callers already driving the grant the emulator's way.

The pending token is what makes the resulting session honest: it records the method that was gated (`password`) rather than falling back to `unknown`, the same way an MFA completion records its primary factor. It is consumed only after the code verifies, and an unknown one is `invalid_pending_authentication_token`.

An invitation passed to the gated password grant is carried across the step-up rather than burned by a 403 the client may never come back from — the deferral rule the MFA and organization-selection paths already follow.

## Behaviour change

A password sign-in by a user with `email_verified: false` now fails. `POST /user_management/users` and seeded `users` both default to `false`, so fixtures that sign in with a password need `email_verified: true` — that is most of this diff, and it is called out in the README.

## Verification

`bun test` (855 pass, 4 new), `bun run typecheck`, `bun run lint`, `bun run fmt:check`.