### PR TITLE
fix(users): populate and shape linked OAuth identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,27 @@ report their own method and need no configuration.)
 users:
   - email: alice@acme.com
     oauth_provider: GoogleOAuth # reported as authentication_method for this user's OAuth logins
+    oauth_idp_id: 108872335 # the user's id at the provider; generated if omitted
 ```
+
+### Linked OAuth identities
+
+`oauth_provider` also links an OAuth identity, so the user is reported by
+`GET /user_management/users/{id}/identities` — a bare array of `{idp_id, type, provider}`, which is
+what the SDKs' `getUserIdentities` deserializes:
+
+```json
+[{ "idp_id": "108872335", "type": "OAuth", "provider": "GoogleOAuth" }]
+```
+
+Completing a login through an OAuth `connection` (`GoogleOAuth`, `MicrosoftOAuth`, `GitHubOAuth`,
+`AppleOAuth`) links one too, carrying the profile's `idp_id`. SAML connections do not: the spec's
+identity `provider` enum is OAuth-only. A second login through the same provider is the same link,
+not another one.
+
+A JWT template reads the same fact as `user.identities` — a provider→`idp_id` map, `null` for every
+provider the user has not linked, so `{{ user.identities.GoogleOAuth }}` renders the id and an
+unlinked provider renders a claim the emulator drops.
 
 ### Machine-to-Machine (M2M) Applications
 

--- a/src/workos/config-validator.ts
+++ b/src/workos/config-validator.ts
@@ -101,6 +101,25 @@ export function validateSeedConfig(config: WorkOSSeedConfig): ConfigValidationRe
             value: user.email_verified,
           });
         }
+        // Both are serialized straight onto the identity the users endpoint returns and the
+        // `user.identities` map a template reads, so a non-string here is a contract the emulator
+        // would break on behalf of a config only YAML or JSON could have written. The provider is
+        // not checked against the spec's enum — `connections[].connection_type` is not either, and
+        // a list baked in here would reject a provider WorkOS adds later.
+        if (user.oauth_provider !== undefined && (typeof user.oauth_provider !== 'string' || !user.oauth_provider)) {
+          errors.push({
+            path: `users[${index}].oauth_provider`,
+            message: 'oauth_provider must be a non-empty string if provided',
+            value: user.oauth_provider,
+          });
+        }
+        if (user.oauth_idp_id !== undefined && (typeof user.oauth_idp_id !== 'string' || !user.oauth_idp_id)) {
+          errors.push({
+            path: `users[${index}].oauth_idp_id`,
+            message: 'oauth_idp_id must be a non-empty string if provided',
+            value: user.oauth_idp_id,
+          });
+        }
       });
 
       // Email is the lookup key org memberships join on; duplicates would silently

--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -145,8 +145,10 @@ export interface WorkOSAuthorizationCode extends Entity {
 export interface WorkOSIdentity extends Entity {
   object: 'identity';
   user_id: string;
+  /** An OAuth provider, e.g. 'GoogleOAuth'. The spec supports no other identity type yet. */
   provider: string;
-  provider_id: string;
+  /** The user's id at the provider. */
+  idp_id: string;
   type: 'OAuth';
 }
 

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -359,8 +359,36 @@ export function formatAuthFactor(f: WorkOSAuthenticationFactor): Record<string, 
   return formatEntity(f);
 }
 
+/**
+ * The spec's identity is the three federated fields and nothing else — no `object`, no `id`, no
+ * timestamps — and its endpoint returns a bare array rather than a list envelope, which is what
+ * the SDKs deserialize (`getUserIdentities` maps the response body directly).
+ */
 export function formatIdentity(i: WorkOSIdentity): Record<string, unknown> {
-  return formatEntity(i);
+  return { idp_id: i.idp_id, type: i.type, provider: i.provider };
+}
+
+/**
+ * Record that `user` signs in through `provider`, idempotently: an identity is a link, and a
+ * second login through the same provider is the same link, not another one. Callers pass the
+ * provider as a spec-valid AuthenticateResponse value ('GoogleOAuth', 'MicrosoftOAuth', …),
+ * which is also what the identity `provider` enum holds.
+ */
+export function linkOAuthIdentity(
+  ws: WorkOSStore,
+  userId: string,
+  provider: string,
+  idpId: string,
+): WorkOSIdentity | undefined {
+  const existing = ws.identities.findBy('user_id', userId).find((i) => i.provider === provider);
+  if (existing) return existing;
+  return ws.identities.insert({
+    object: 'identity',
+    user_id: userId,
+    provider,
+    idp_id: idpId,
+    type: 'OAuth',
+  });
 }
 
 export function generateVerificationToken(): string {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -374,15 +374,9 @@ export function formatIdentity(i: WorkOSIdentity): Record<string, unknown> {
  * provider as a spec-valid AuthenticateResponse value ('GoogleOAuth', 'MicrosoftOAuth', …),
  * which is also what the identity `provider` enum holds.
  */
-export function linkOAuthIdentity(
-  ws: WorkOSStore,
-  userId: string,
-  provider: string,
-  idpId: string,
-): WorkOSIdentity | undefined {
-  const existing = ws.identities.findBy('user_id', userId).find((i) => i.provider === provider);
-  if (existing) return existing;
-  return ws.identities.insert({
+export function linkOAuthIdentity(ws: WorkOSStore, userId: string, provider: string, idpId: string): void {
+  if (ws.identities.findBy('user_id', userId).some((i) => i.provider === provider)) return;
+  ws.identities.insert({
     object: 'identity',
     user_id: userId,
     provider,

--- a/src/workos/identities.spec.ts
+++ b/src/workos/identities.spec.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, afterEach } from 'bun:test';
 import { createEmulator, type Emulator } from '../index.js';
+import { validateSeedConfig } from './config-validator.js';
 
 describe('User identities', () => {
   let emulator: Emulator | undefined;
@@ -112,6 +113,23 @@ describe('User identities', () => {
     const profile = await ssoLogin('saml@acme.test');
     expect(profile.profile.idp_id).toBeString();
     expect(await identitiesOf('user_saml')).toEqual([]);
+  });
+
+  // Both fields are serialized straight onto the identity, so a seed only YAML or JSON could have
+  // written must not be the way a non-string reaches the endpoint's declared shape.
+  it('rejects a seeded provider or idp_id that is not a string', () => {
+    const { valid, errors } = validateSeedConfig({
+      users: [
+        {
+          email: 'bad@acme.test',
+          oauth_provider: 42 as unknown as string,
+          oauth_idp_id: '' as unknown as string,
+        },
+      ],
+    });
+
+    expect(valid).toBe(false);
+    expect(errors.map((e) => e.path)).toEqual(['users[0].oauth_provider', 'users[0].oauth_idp_id']);
   });
 
   it('lets a JWT template read a linked identity', async () => {

--- a/src/workos/identities.spec.ts
+++ b/src/workos/identities.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Linked OAuth identities. Nothing used to write to the identities collection, so
+ * `GET /user_management/users/{id}/identities` answered every user, in every state, with an
+ * empty list — and a JWT template could only ever see the provider→null map. See #66.
+ */
+import { describe, it, expect, afterEach } from 'bun:test';
+import { createEmulator, type Emulator } from '../index.js';
+
+describe('User identities', () => {
+  let emulator: Emulator | undefined;
+
+  afterEach(async () => {
+    await emulator?.close();
+    emulator = undefined;
+  });
+
+  const auth = (apiKey: string) => ({ Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' });
+
+  const identitiesOf = async (userId: string) =>
+    (await (
+      await fetch(`${emulator!.url}/user_management/users/${userId}/identities`, {
+        headers: auth(emulator!.apiKey),
+      })
+    ).json()) as any;
+
+  const firstUser = async () =>
+    ((await (await fetch(`${emulator!.url}/user_management/users`, { headers: auth(emulator!.apiKey) })).json()) as any)
+      .data[0];
+
+  /** Walk /sso/authorize → /sso/token for `email` through the seeded connection. */
+  async function ssoLogin(email: string) {
+    const authorize = await fetch(
+      `${emulator!.url}/sso/authorize?redirect_uri=http://localhost:3000/callback&domain_hint=acme.test&login_hint=${encodeURIComponent(email)}`,
+      { redirect: 'manual' },
+    );
+    const code = new URL(authorize.headers.get('location')!).searchParams.get('code');
+    const token = await fetch(`${emulator!.url}/sso/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'authorization_code', code }),
+    });
+    return (await token.json()) as any;
+  }
+
+  it('reports the identity a seeded oauth_provider stands for, in the spec shape', async () => {
+    emulator = await createEmulator({
+      port: 0,
+      seed: {
+        users: [
+          { id: 'user_sso', email: 'sso@acme.test', oauth_provider: 'GoogleOAuth', oauth_idp_id: 'idp_user_123' },
+          { id: 'user_plain', email: 'plain@acme.test' },
+        ],
+      },
+    });
+
+    // A bare array of {idp_id, type, provider} — not a list envelope, and no entity fields.
+    expect(await identitiesOf('user_sso')).toEqual([
+      { idp_id: 'idp_user_123', type: 'OAuth', provider: 'GoogleOAuth' },
+    ]);
+    // A user told nothing about a provider still has no identity: nothing is invented.
+    expect(await identitiesOf('user_plain')).toEqual([]);
+  });
+
+  it('links an identity when a login completes through an OAuth connection', async () => {
+    emulator = await createEmulator({
+      port: 0,
+      seed: {
+        users: [{ id: 'user_fed', email: 'fed@acme.test' }],
+        organizations: [{ name: 'Acme', domains: [{ domain: 'acme.test', state: 'verified' }] }],
+        connections: [
+          {
+            name: 'Acme SSO',
+            organization: 'Acme',
+            connection_type: 'GoogleOAuth',
+            domains: ['acme.test'],
+            profiles: [{ email: 'fed@acme.test', idp_id: 'idp_google_9' }],
+          },
+        ],
+      },
+    });
+
+    expect(await identitiesOf('user_fed')).toEqual([]);
+
+    await ssoLogin('fed@acme.test');
+    expect(await identitiesOf('user_fed')).toEqual([
+      { idp_id: 'idp_google_9', type: 'OAuth', provider: 'GoogleOAuth' },
+    ]);
+
+    // A second login through the same provider is the same link, not another one.
+    await ssoLogin('fed@acme.test');
+    expect(await identitiesOf('user_fed')).toHaveLength(1);
+  });
+
+  it('links nothing for a SAML connection, which is not an OAuth identity', async () => {
+    emulator = await createEmulator({
+      port: 0,
+      seed: {
+        users: [{ id: 'user_saml', email: 'saml@acme.test' }],
+        organizations: [{ name: 'Acme', domains: [{ domain: 'acme.test', state: 'verified' }] }],
+        connections: [
+          {
+            name: 'Acme SAML',
+            organization: 'Acme',
+            connection_type: 'OktaSAML',
+            domains: ['acme.test'],
+            profiles: [{ email: 'saml@acme.test' }],
+          },
+        ],
+      },
+    });
+
+    const profile = await ssoLogin('saml@acme.test');
+    expect(profile.profile.idp_id).toBeString();
+    expect(await identitiesOf('user_saml')).toEqual([]);
+  });
+
+  it('lets a JWT template read a linked identity', async () => {
+    emulator = await createEmulator({
+      port: 0,
+      seed: {
+        users: [
+          {
+            email: 'claims@acme.test',
+            password: 'test123',
+            email_verified: true,
+            oauth_provider: 'GoogleOAuth',
+            oauth_idp_id: 'idp_user_123',
+          },
+        ],
+        jwtTemplate: {
+          content:
+            '{"urn:myapp:google": "{{ user.identities.GoogleOAuth }}", "urn:myapp:apple": {{ user.identities.AppleOAuth }}}',
+        },
+      },
+    });
+
+    const res = await fetch(`${emulator.url}/user_management/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'password', email: 'claims@acme.test', password: 'test123' }),
+    });
+    const { access_token } = (await res.json()) as any;
+    const claims = JSON.parse(Buffer.from(access_token.split('.')[1], 'base64url').toString('utf-8'));
+
+    expect(claims['urn:myapp:google']).toBe('idp_user_123');
+    // Unlinked providers stay null, so a template can tell "not linked" from a linked id.
+    expect(claims['urn:myapp:apple']).toBeUndefined();
+
+    // The endpoint and the template agree about what is linked.
+    const user = await firstUser();
+    expect(await identitiesOf(user.id)).toEqual([{ idp_id: 'idp_user_123', type: 'OAuth', provider: 'GoogleOAuth' }]);
+  });
+});

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -66,6 +66,7 @@ import {
   formatFeatureFlag,
   generateClientId,
   findUserByEmail,
+  linkOAuthIdentity,
 } from './helpers.js';
 import type {
   WorkOSConnectionType,
@@ -135,8 +136,18 @@ export interface WorkOSSeedUser {
    * OAuth-based grants (authorization_code, refresh_token, device_code). Must be a spec-valid
    * value such as 'GoogleOAuth' or 'MicrosoftOAuth'. When omitted the emulator leaves
    * authentication_method off the response rather than guessing a provider.
+   *
+   * Setting it also links an OAuth identity, so the user is returned by
+   * `GET /user_management/users/{id}/identities` and readable as `user.identities` in a JWT
+   * template.
    */
   oauth_provider?: string;
+  /**
+   * The user's id at `oauth_provider`, reported as the linked identity's `idp_id`. Generated if
+   * omitted. Pin it to match what your real WorkOS environment emits. Ignored without
+   * `oauth_provider` — there is no identity to put it on.
+   */
+  oauth_idp_id?: string;
 }
 
 export interface WorkOSSeedConnection {
@@ -286,7 +297,7 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: WorkOSSee
 
   if (config.users) {
     for (const userConfig of config.users) {
-      ws.users.insert({
+      const user = ws.users.insert({
         object: 'user',
         id: userConfig.id,
         // Trimmed, as both routes that create users store it: a padded seed would otherwise be
@@ -306,6 +317,18 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: WorkOSSee
         impersonator: userConfig.impersonator ?? null,
         oauth_provider: userConfig.oauth_provider ?? null,
       });
+
+      // Being told a user authenticates with an OAuth provider is being told they have a linked
+      // identity: it is the same fact `GET /user_management/users/{id}/identities` reports, so a
+      // seed that sets one no longer has to also be an account with no identities at all.
+      if (userConfig.oauth_provider) {
+        linkOAuthIdentity(
+          ws,
+          user.id,
+          userConfig.oauth_provider,
+          userConfig.oauth_idp_id ?? `idp_${generateId('usr')}`,
+        );
+      }
     }
   }
 

--- a/src/workos/jwt-template.ts
+++ b/src/workos/jwt-template.ts
@@ -191,11 +191,12 @@ export function renderJwtTemplate(content: string, context: JwtTemplateContext):
 
 /**
  * The OAuth provider keys observed in the production JWT template context's
- * `user.identities` map. The emulator does not model identity linking, so every
- * provider maps to null — matching a user with no linked identities. Note
- * GitHubOAuth uses a capital-H per the measured production context.
+ * `user.identities` map. Every provider maps to null — a user with no linked identities —
+ * and a provider the user has actually linked is overlaid with its `idp_id` in
+ * `buildJwtTemplateContext`. Note GitHubOAuth uses a capital-H per the measured
+ * production context.
  */
-const OAUTH_IDENTITIES_MAP: Record<string, null> = {
+const OAUTH_IDENTITIES_MAP: Record<string, string | null> = {
   AppleOAuth: null,
   GitHubOAuth: null,
   GoogleOAuth: null,
@@ -296,8 +297,8 @@ export function validateJwtTemplateContent(content: unknown): string[] {
  * Assemble the variables a template can read for one sign-in. Mirrors the production
  * WorkOS JWT template context: `user` and `organization` are built from the format*
  * helpers (so they track the API response shape), with the adjustments prod's template
- * context makes on top — `user.identities` is added (a provider→null map for users with
- * no linked identity) and `user.last_sign_in_at` is dropped. `organization_membership`
+ * context makes on top — `user.identities` is added (a provider→`idp_id` map, null for every
+ * provider the user has not linked) and `user.last_sign_in_at` is dropped. `organization_membership`
  * is built explicitly with the context-only shape (string `role`/`roles`, no
  * `external_id`/`metadata`).
  *
@@ -309,9 +310,16 @@ export function buildJwtTemplateContext(
   user: WorkOSUser,
   organizationId?: string | null,
 ): JwtTemplateContext {
+  // A linked provider carries the user's id at that provider; the rest stay null. The map is
+  // copied rather than mutated — it is module state shared by every render.
+  const identities: Record<string, string | null> = { ...OAUTH_IDENTITIES_MAP };
+  for (const identity of ws.identities.findBy('user_id', user.id)) {
+    identities[identity.provider] = identity.idp_id;
+  }
+
   const userContext: Record<string, unknown> = {
     ...formatUser(user),
-    identities: OAUTH_IDENTITIES_MAP,
+    identities,
   };
   // `last_sign_in_at` is on the API response but omitted from the JWT template context
   // by production.

--- a/src/workos/routes/sso.ts
+++ b/src/workos/routes/sso.ts
@@ -9,11 +9,24 @@ import {
   emitAuthenticationEvent,
   findUserByEmail,
   emailsMatch,
+  linkOAuthIdentity,
 } from '../helpers.js';
-import type { WorkOSConnection } from '../entities.js';
+import type { WorkOSConnection, WorkOSConnectionType } from '../entities.js';
 import type { EventBus } from '../event-bus.js';
 import { STORE_KEY_PREFIXES, STORE_KEYS } from '../constants.js';
 import { renderLoginPage } from '../login-page.js';
+
+/**
+ * The connection types that federate through OAuth rather than SAML. Their names are exactly the
+ * spec's identity `provider` values, which is why a login through one can be recorded as a linked
+ * identity and a SAML login cannot.
+ */
+const OAUTH_CONNECTION_TYPES = new Set<WorkOSConnectionType>([
+  'AppleOAuth',
+  'GitHubOAuth',
+  'GoogleOAuth',
+  'MicrosoftOAuth',
+]);
 
 interface SSOAuthorizeParams {
   redirectUri: string;
@@ -239,12 +252,22 @@ export function ssoRoutes(ctx: RouteContext): void {
     // SSO is profile-based; a user-management user may not exist for this email. Resolved
     // case-insensitively, like every other lookup by email, so the event carries the id of an
     // account stored under a different case rather than reporting none.
+    const authenticatedUser = findUserByEmail(ws, profile.email);
+
+    // A completed login through an OAuth connection is what identity linking records, so this is
+    // where the identity the users endpoint reports comes from. SAML connections are skipped: the
+    // spec's identity `provider` enum is OAuth-only, and "currently only OAuth identities are
+    // supported".
+    if (authenticatedUser && OAUTH_CONNECTION_TYPES.has(profile.connection_type)) {
+      linkOAuthIdentity(ws, authenticatedUser.id, profile.connection_type, profile.idp_id);
+    }
+
     emitAuthenticationEvent({
       eventBus: store.getData<EventBus>(STORE_KEYS.eventBus),
       method: 'SSO',
       status: 'succeeded',
       email: profile.email,
-      userId: findUserByEmail(ws, profile.email)?.id ?? null,
+      userId: authenticatedUser?.id ?? null,
       ipAddress: c.req.header('x-forwarded-for') ?? null,
       userAgent: c.req.header('user-agent') ?? null,
       sso: {

--- a/src/workos/routes/users.ts
+++ b/src/workos/routes/users.ts
@@ -161,11 +161,7 @@ export function userRoutes(ctx: RouteContext): void {
     const user = ws.users.get(c.req.param('id'));
     if (!user) throw notFound('User');
 
-    const identities = ws.identities.findBy('user_id', user.id);
-    return c.json({
-      object: 'list',
-      data: identities.map(formatIdentity),
-      list_metadata: { before: null, after: null },
-    });
+    // A bare array, per the spec: this endpoint is not paginated and returns no list envelope.
+    return c.json(ws.identities.findBy('user_id', user.id).map(formatIdentity));
   });
 }


### PR DESCRIPTION
Fixes #66.

Nothing wrote to the `identities` collection, so the endpoint answered every user, in every state, with an empty list. Two paths now record a link, and both are facts the emulator was already being told:

- **A seeded `oauth_provider`.** Saying a user authenticates with a provider *is* saying they have a linked identity — it is the same fact this endpoint reports — so it no longer takes a second, separate knob. An optional `oauth_idp_id` pins the provider-side id the way the rest of the seed file lets you pin what production emits; it is generated otherwise.
- **A login completing through an OAuth connection**, carrying the profile's `idp_id`. SAML connections link nothing: the spec's identity `provider` enum is OAuth-only ("currently only OAuth identities are supported"), so `GoogleOAuth`/`MicrosoftOAuth`/`GitHubOAuth`/`AppleOAuth` link and `GoogleSAML` does not. Linking is idempotent — a second login through the same provider is the same link.

Your reproduction now returns `[{"idp_id":"...","type":"OAuth","provider":"GoogleOAuth"}]` for `user_sso`.

## The response shape was also wrong

The spec returns a **bare array** of `{idp_id, type, provider}` — no `object`/`data`/`list_metadata` envelope, no `id`, no timestamps — and that is what the SDKs deserialize (`getUserIdentities` maps the response body directly). An empty list envelope hid that; returning data would not have, so it is fixed in the same change. The entity's `provider_id` is renamed `idp_id` to match.

## The template context

`OAUTH_IDENTITIES_MAP` is now the *base*, not the answer: a provider the user has actually linked is overlaid with its `idp_id`, so `{{ user.identities.GoogleOAuth }}` renders the id and every unlinked provider still renders `null`. The map is copied per render rather than mutated — it is module state shared by every sign-in.

## Not covered

An identity-linking *API* (there is no route to create one, and the spec defines no write endpoint here), and `connected_accounts`, which is a separate resource.

## Verification

`bun test` (855 pass, 4 new in `src/workos/identities.spec.ts` — the issue's reproduction end to end), `bun run typecheck`, `bun run lint`, `bun run fmt:check`.
