### PR TITLE
feat(auth): interactive organization selection, and an account picker on the sign-in page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1151,19 +1151,43 @@ const emulator = await createEmulator({
 
 ### What changes
 
-| Endpoint                         | Default (auto)                                   | Interactive                                   |
-| -------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| `GET /sso/authorize`             | Immediately redirects to callback with auth code | Serves an HTML login page with an email field |
-| `GET /user_management/authorize` | Immediately redirects to callback with auth code | Serves an HTML login page with an email field |
+| Endpoint                         | Default (auto)                                   | Interactive                                                                                             |
+| -------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `GET /sso/authorize`             | Immediately redirects to callback with auth code | Serves an HTML login page with an email field                                                           |
+| `GET /user_management/authorize` | Immediately redirects to callback with auth code | Serves an HTML login page with an email field, plus a collapsed list of the accounts the emulator holds |
 
 When interactive mode is on:
 
 1. Your app redirects to `/sso/authorize?connection=...&redirect_uri=...` (or `/user_management/authorize?...`)
 2. The emulator serves a login page instead of auto-redirecting
 3. The browser (or agent) fills in the email field and submits the form
-4. The emulator creates an auth code and redirects back to your app's callback URL
+4. If the user belongs to more than one organization, the emulator asks which one, as hosted AuthKit does
+5. The emulator creates an auth code and redirects back to your app's callback URL
 
 The `login_hint` parameter pre-fills the email field, so agent browsers can skip typing if desired.
+
+### Picking an account
+
+The login page also lists every account the emulator holds, collapsed behind **Pick an account (N)** and ordered by email, so a test does not have to hard-code an address to sign in as one. Each row submits directly. A user created through the API mid-session appears in the list too. Typing an address that was never seeded still works, which is what sign-up flows rely on.
+
+### Choosing an organization
+
+A user with more than one active membership gets a second page, one row per organization, before any code is minted. This mirrors hosted AuthKit, and it matters because the alternative is the API-level `organization_selection_required` response, which a browser client receives mid-callback and cannot act on.
+
+Skip the page by passing `organization_id` to `/user_management/authorize`; it must be one the user is an active member of, or the request is refused. If the membership behind a code is revoked before the code is redeemed, redemption fails with `invalid_grant` rather than silently signing the user into a different tenant.
+
+```ts
+test('multi-organization login', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+  await page.fill('input[name="email"]', 'alice@example.com');
+  await page.click('button[type="submit"]');
+
+  // Only shown when the user belongs to several organizations
+  await page.click('text=Acme');
+
+  await expect(page).toHaveURL(/dashboard/);
+});
+```
 
 ### E2E example with Playwright
 

--- a/src/workos/login-page.ts
+++ b/src/workos/login-page.ts
@@ -78,10 +78,7 @@ export function renderDeviceVerifyPage(options: DeviceVerifyPageOptions): string
 export function renderLoginPage(options: LoginPageOptions): string {
   const { title, subtitle, emailHint, formAction, hiddenFields, users } = options;
 
-  const hiddenInputs = Object.entries(hiddenFields)
-    .filter(([, v]) => v != null)
-    .map(([name, value]) => `<input type="hidden" name="${esc(name)}" value="${esc(value)}">`)
-    .join('\n        ');
+  const hiddenInputs = renderHiddenInputs(hiddenFields);
 
   // Sorted by email, and by email rather than name because a name is optional. Store order
   // would put whatever was created most recently at the bottom, which moves the rows under
@@ -176,10 +173,7 @@ ${accounts
 export function renderOrganizationSelectPage(options: OrganizationSelectPageOptions): string {
   const { email, organizations, formAction, hiddenFields } = options;
 
-  const hiddenInputs = Object.entries(hiddenFields)
-    .filter(([, v]) => v != null)
-    .map(([name, value]) => `<input type="hidden" name="${esc(name)}" value="${esc(value)}">`)
-    .join('\n        ');
+  const hiddenInputs = renderHiddenInputs(hiddenFields);
 
   const rows = organizations
     .map(
@@ -224,6 +218,14 @@ ${rows}
   </div>
 </body>
 </html>`;
+}
+
+/** Hidden `<input>` elements for a form's carried-through fields, dropping null/undefined values. */
+function renderHiddenInputs(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .filter(([, v]) => v != null)
+    .map(([name, value]) => `<input type="hidden" name="${esc(name)}" value="${esc(value)}">`)
+    .join('\n        ');
 }
 
 function esc(str: string): string {

--- a/src/workos/login-page.ts
+++ b/src/workos/login-page.ts
@@ -4,6 +4,26 @@ export interface LoginPageOptions {
   emailHint?: string;
   formAction: string;
   hiddenFields: Record<string, string>;
+  /**
+   * Accounts to offer beneath the email field, collapsed behind a disclosure. Every user the
+   * emulator holds, not only the seeded ones: a user created through the API mid-session appears
+   * here too, which is what makes the list useful for testing a sign-up.
+   *
+   * Collapsed by default, so the page an unknown address or a sign-up arrives at is the page it
+   * has always been. Flat rather than grouped by organization, because the emulator asks which
+   * organization in its own later step and grouping here would imply a choice this page does not
+   * make. Each account is a submit button in a second form, so picking one is a single click and
+   * `<details>` does the expanding, which leaves the page with no JavaScript. The list scrolls
+   * rather than growing the card, so a large store stays usable. Omitted or empty renders the
+   * page exactly as before.
+   */
+  users?: LoginPageUser[];
+}
+
+/** A seeded account offered on the sign-in page, so a developer picks rather than remembers. */
+export interface LoginPageUser {
+  email: string;
+  name?: string | null;
 }
 
 /** One organization a user may finish signing in to. */
@@ -56,12 +76,38 @@ export function renderDeviceVerifyPage(options: DeviceVerifyPageOptions): string
 }
 
 export function renderLoginPage(options: LoginPageOptions): string {
-  const { title, subtitle, emailHint, formAction, hiddenFields } = options;
+  const { title, subtitle, emailHint, formAction, hiddenFields, users } = options;
 
   const hiddenInputs = Object.entries(hiddenFields)
     .filter(([, v]) => v != null)
     .map(([name, value]) => `<input type="hidden" name="${esc(name)}" value="${esc(value)}">`)
     .join('\n        ');
+
+  // Sorted by email, and by email rather than name because a name is optional. Store order
+  // would put whatever was created most recently at the bottom, which moves the rows under
+  // someone mid-session; lexical keeps a given account in the same place. Copied first, so the
+  // caller's slice is not reordered underneath it.
+  const accounts = [...(users ?? [])].sort((a, b) => a.email.localeCompare(b.email, 'en'));
+  const picker =
+    accounts.length === 0
+      ? ''
+      : `
+    <details class="accounts">
+      <summary>Pick an account (${accounts.length})</summary>
+      <form method="POST" action="${esc(formAction)}">
+        ${hiddenInputs}
+        <div class="account-list">
+${accounts
+  .map(
+    (u) => `          <button class="account" type="submit" name="email" value="${esc(u.email)}">
+            <span class="who">${u.name ? `<span class="name">${esc(u.name)}</span>` : ''}<span class="email">${esc(u.email)}</span></span>
+            <span class="chevron" aria-hidden="true">&rsaquo;</span>
+          </button>`,
+  )
+  .join('\n')}
+        </div>
+      </form>
+    </details>`;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -81,6 +127,21 @@ export function renderLoginPage(options: LoginPageOptions): string {
     input[type="email"]:focus{border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.1)}
     button{width:100%;padding:10px;background:#6366f1;color:#fff;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;margin-top:16px}
     button:hover{background:#4f46e5}
+    .accounts{margin-top:24px;border-top:1px solid #e5e7eb;padding-top:16px}
+    .accounts summary{cursor:pointer;font-size:13px;color:#6b7280;list-style:none}
+    .accounts summary::-webkit-details-marker{display:none}
+    .accounts summary::before{content:"\\203A";display:inline-block;margin-right:6px;transition:transform .15s}
+    .accounts[open] summary::before{transform:rotate(90deg)}
+    .accounts summary:hover{color:#111827}
+    .account-list{margin-top:12px;max-height:220px;overflow-y:auto;border:1px solid #e5e7eb;border-radius:6px}
+    .account{display:flex;align-items:center;justify-content:space-between;width:100%;padding:10px 14px;background:#fff;border:none;border-bottom:1px solid #e5e7eb;text-align:left;cursor:pointer;margin-top:0}
+    .account:last-child{border-bottom:none}
+    .account:hover{background:#f9fafb}
+    .account:focus-visible{outline:2px solid #6366f1;outline-offset:-2px}
+    .who{display:flex;flex-direction:column;gap:2px}
+    .name{font-size:14px;font-weight:500;color:#111827}
+    .email{font-size:12px;color:#6b7280}
+    .chevron{color:#9ca3af;font-size:18px;line-height:1}
   </style>
 </head>
 <body>
@@ -93,7 +154,7 @@ export function renderLoginPage(options: LoginPageOptions): string {
         <label for="email">Email</label>
         <input type="email" id="email" name="email" value="${esc(emailHint ?? '')}" required autofocus>
         <button type="submit">Continue</button>
-    </form>
+    </form>${picker}
   </div>
 </body>
 </html>`;

--- a/src/workos/login-page.ts
+++ b/src/workos/login-page.ts
@@ -6,6 +6,20 @@ export interface LoginPageOptions {
   hiddenFields: Record<string, string>;
 }
 
+/** One organization a user may finish signing in to. */
+export interface SelectableOrganization {
+  id: string;
+  name: string;
+}
+
+export interface OrganizationSelectPageOptions {
+  /** Who is signing in, so it is obvious whose organizations these are. */
+  email: string;
+  organizations: SelectableOrganization[];
+  formAction: string;
+  hiddenFields: Record<string, string>;
+}
+
 export interface DeviceVerifyPageOptions {
   title: string;
   message: string;
@@ -79,6 +93,72 @@ export function renderLoginPage(options: LoginPageOptions): string {
         <label for="email">Email</label>
         <input type="email" id="email" name="email" value="${esc(emailHint ?? '')}" required autofocus>
         <button type="submit">Continue</button>
+    </form>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * The screen hosted AuthKit shows when a user belongs to more than one organization: a row per
+ * organization, picked before anything is minted.
+ *
+ * Rendered during authorize rather than at the token exchange, because that is where production
+ * asks. The code then carries the organization and the client's exchange succeeds. Without this
+ * step the emulator answers the exchange with `organization_selection_required`, which is an
+ * API-level response a browser client has no way to act on: it surfaces mid-callback as a failed
+ * exchange, and the user is simply stuck.
+ *
+ * Each row is a submit button carrying its own organization id, so picking is one click and the
+ * page still needs no JavaScript.
+ */
+export function renderOrganizationSelectPage(options: OrganizationSelectPageOptions): string {
+  const { email, organizations, formAction, hiddenFields } = options;
+
+  const hiddenInputs = Object.entries(hiddenFields)
+    .filter(([, v]) => v != null)
+    .map(([name, value]) => `<input type="hidden" name="${esc(name)}" value="${esc(value)}">`)
+    .join('\n        ');
+
+  const rows = organizations
+    .map(
+      (org) => `          <button class="org" type="submit" name="organization_id" value="${esc(org.id)}">
+            <span>${esc(org.name)}</span><span class="chevron" aria-hidden="true">&rsaquo;</span>
+          </button>`,
+    )
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Select an organization — WorkOS Emulate</title>
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f5;display:flex;justify-content:center;align-items:center;min-height:100vh}
+    .card{background:#fff;border-radius:8px;padding:40px;width:400px;box-shadow:0 2px 8px rgba(0,0,0,.1)}
+    .badge{display:inline-block;background:#6366f1;color:#fff;font-size:11px;font-weight:600;padding:3px 8px;border-radius:4px;margin-bottom:16px;letter-spacing:.5px}
+    h1{font-size:22px;font-weight:600;margin-bottom:8px}
+    .sub{color:#6b7280;font-size:14px;margin-bottom:24px}
+    .orgs{border:1px solid #e5e7eb;border-radius:6px;overflow:hidden}
+    .org{display:flex;align-items:center;justify-content:space-between;width:100%;padding:14px 16px;background:#fff;border:none;border-bottom:1px solid #e5e7eb;font-size:14px;color:#111827;text-align:left;cursor:pointer}
+    .org:last-child{border-bottom:none}
+    .org:hover{background:#f9fafb}
+    .org:focus-visible{outline:2px solid #6366f1;outline-offset:-2px}
+    .chevron{color:#9ca3af;font-size:18px;line-height:1}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">WORKOS EMULATE</div>
+    <h1>Select an organization</h1>
+    <p class="sub">${esc(email)} belongs to more than one organization.</p>
+    <form method="POST" action="${esc(formAction)}">
+        ${hiddenInputs}
+        <div class="orgs">
+${rows}
+        </div>
     </form>
   </div>
 </body>

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2376,6 +2376,42 @@ describe('AuthKit interactive auth', () => {
     expect(ws.authCodes.findOneBy('code', code)?.organization_id).toBe(chosen.id);
   });
 
+  it('drops a code\u2019s organization when the membership is revoked before redemption', async () => {
+    const ws = getWorkOSStore(store);
+    const user = seedUser(ws, 'revoked@test.com');
+    const org = joinOrg(user.id, 'Acme');
+
+    const authorize = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        redirect_uri: 'http://localhost:3000/callback',
+        email: 'revoked@test.com',
+        organization_id: org.id,
+      }),
+    });
+    const code = new URL(authorize.headers.get('location')!).searchParams.get('code')!;
+
+    // Revoked inside the code's ten minute window, which is the whole point: the code still
+    // names the organization.
+    const membership = ws.organizationMemberships.findBy('user_id', user.id)[0]!;
+    const deactivated = await app.request(`/user_management/organization_memberships/${membership.id}/deactivate`, {
+      method: 'PUT',
+      headers,
+    });
+    expect(deactivated.status).toBe(200);
+
+    const res = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'authorization_code', code }),
+    });
+
+    expect(res.status).toBe(200);
+    // Not scoped to the organization the code named, because the membership behind it is gone.
+    expect((await json(res)).organization_id).not.toBe(org.id);
+  });
+
   it('POST /user_management/authorize refuses an organization the user is not in', async () => {
     const ws = getWorkOSStore(store);
     seedUser(ws, 'outsider@test.com');

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2376,40 +2376,69 @@ describe('AuthKit interactive auth', () => {
     expect(ws.authCodes.findOneBy('code', code)?.organization_id).toBe(chosen.id);
   });
 
-  it('drops a code\u2019s organization when the membership is revoked before redemption', async () => {
-    const ws = getWorkOSStore(store);
-    const user = seedUser(ws, 'revoked@test.com');
-    const org = joinOrg(user.id, 'Acme');
-
-    const authorize = await app.request('/user_management/authorize', {
+  /** Mint an organization-scoped code the way the selection page does. */
+  const mintScopedCode = async (email: string, organizationId: string) => {
+    const res = await app.request('/user_management/authorize', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({
         redirect_uri: 'http://localhost:3000/callback',
-        email: 'revoked@test.com',
-        organization_id: org.id,
+        email,
+        organization_id: organizationId,
       }),
     });
-    const code = new URL(authorize.headers.get('location')!).searchParams.get('code')!;
+    return new URL(res.headers.get('location')!).searchParams.get('code')!;
+  };
 
-    // Revoked inside the code's ten minute window, which is the whole point: the code still
-    // names the organization.
-    const membership = ws.organizationMemberships.findBy('user_id', user.id)[0]!;
-    const deactivated = await app.request(`/user_management/organization_memberships/${membership.id}/deactivate`, {
+  const revokeMembership = async (userId: string, organizationId: string) => {
+    const membership = getWorkOSStore(store)
+      .organizationMemberships.findBy('user_id', userId)
+      .find((m) => m.organization_id === organizationId)!;
+    const res = await app.request(`/user_management/organization_memberships/${membership.id}/deactivate`, {
       method: 'PUT',
       headers,
     });
-    expect(deactivated.status).toBe(200);
+    expect(res.status).toBe(200);
+  };
 
-    const res = await app.request('/user_management/authenticate', {
+  const redeem = (code: string) =>
+    app.request('/user_management/authenticate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ grant_type: 'authorization_code', code }),
     });
 
-    expect(res.status).toBe(200);
-    // Not scoped to the organization the code named, because the membership behind it is gone.
-    expect((await json(res)).organization_id).not.toBe(org.id);
+  it('refuses a code whose organization membership was revoked before redemption', async () => {
+    const ws = getWorkOSStore(store);
+    const user = seedUser(ws, 'revoked@test.com');
+    const org = joinOrg(user.id, 'Acme');
+
+    const code = await mintScopedCode('revoked@test.com', org.id);
+    await revokeMembership(user.id, org.id);
+
+    const res = await redeem(code);
+
+    expect(res.status).toBe(400);
+    expect((await json(res)).error).toBe('invalid_grant');
+  });
+
+  it('refuses rather than silently signing the user into their other organization', async () => {
+    const ws = getWorkOSStore(store);
+    const user = seedUser(ws, 'switcheroo@test.com');
+    const picked = joinOrg(user.id, 'Picked');
+    const other = joinOrg(user.id, 'Other');
+
+    const code = await mintScopedCode('switcheroo@test.com', picked.id);
+    await revokeMembership(user.id, picked.id);
+
+    // Exactly one active membership is left, so re-resolving would have found it and signed the
+    // user into a tenant they never chose.
+    const res = await redeem(code);
+
+    expect(res.status).toBe(400);
+    const body = await json(res);
+    expect(body.error).toBe('invalid_grant');
+    expect(JSON.stringify(body)).not.toContain(other.id);
   });
 
   it('POST /user_management/authorize refuses an organization the user is not in', async () => {

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2381,6 +2381,51 @@ describe('AuthKit interactive auth', () => {
     expect(ws.authCodes.findOneBy('code', code)?.organization_id).toBe(chosen.id);
   });
 
+  it('POST /user_management/authorize refuses an organization the user is not in', async () => {
+    const ws = getWorkOSStore(store);
+    seedUser(ws, 'outsider@test.com');
+    const other = ws.organizations.insert({
+      object: 'organization',
+      name: 'Someone Else',
+      external_id: null,
+      stripe_customer_id: null,
+      metadata: {},
+    } as any);
+
+    const res = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        redirect_uri: 'http://localhost:3000/callback',
+        email: 'outsider@test.com',
+        organization_id: other.id,
+      }),
+    });
+
+    // Not a redirect: a code scoped to an organization with no membership behind it puts that
+    // org_id on the token with no role or permissions, which is the wrong tenant for anything
+    // authorizing on it.
+    expect(res.status).toBe(400);
+    expect((await json(res)).code).toBe('invalid_request');
+  });
+
+  it('POST /user_management/authorize refuses an organization that does not exist', async () => {
+    const ws = getWorkOSStore(store);
+    seedUser(ws, 'nobody@test.com');
+
+    const res = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        redirect_uri: 'http://localhost:3000/callback',
+        email: 'nobody@test.com',
+        organization_id: 'org_does_not_exist',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   it('POST /user_management/authorize redirects straight through for a single-organization user', async () => {
     const ws = getWorkOSStore(store);
     seedUser(ws, 'single@test.com');

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2429,6 +2429,36 @@ describe('AuthKit interactive auth', () => {
     expect(res.headers.get('location')).toContain('code=');
   });
 
+  it('GET /user_management/authorize carries organization_id through the login page, skipping the selection page', async () => {
+    const ws = getWorkOSStore(store);
+    const user = seedUser(ws, 'preset@test.com');
+    const chosen = joinOrg(user.id, 'Preset Org');
+    joinOrg(user.id, 'Other Org');
+
+    // A caller that already knows the organization pins it on the GET. It must travel through the
+    // login page as a hidden field so the POST can mint a scoped code without stopping on the
+    // selection page — even though this user belongs to several organizations.
+    const page = await app.request(
+      `/user_management/authorize?redirect_uri=http://localhost:3000/callback&login_hint=preset@test.com&organization_id=${chosen.id}`,
+    );
+    const html = await page.text();
+    expect(html).toContain(`name="organization_id" value="${chosen.id}"`);
+
+    const res = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        redirect_uri: 'http://localhost:3000/callback',
+        email: 'preset@test.com',
+        organization_id: chosen.id,
+      }),
+    });
+
+    expect(res.status).toBe(302);
+    const code = new URL(res.headers.get('location')!).searchParams.get('code')!;
+    expect(ws.authCodes.findOneBy('code', code)?.organization_id).toBe(chosen.id);
+  });
+
   it('GET /user_management/authorize pre-fills login_hint', async () => {
     const res = await app.request(
       '/user_management/authorize?redirect_uri=http://localhost:3000/callback&login_hint=bob@test.com',

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2200,6 +2200,32 @@ describe('AuthKit interactive auth', () => {
 
   const json = (res: Response) => res.json() as Promise<any>;
 
+  /** Mirrors createOrg/joinOrg in the 'Auth routes' block above, which are out of scope here. */
+  const createOrg = (name: string) =>
+    getWorkOSStore(store).organizations.insert({
+      object: 'organization',
+      name,
+      external_id: null,
+      metadata: {},
+      stripe_customer_id: null,
+      allow_profiles_outside_organization: false,
+      entitlements: [],
+    });
+
+  const joinOrg = (userId: string, name: string) => {
+    const org = createOrg(name);
+    getWorkOSStore(store).organizationMemberships.insert({
+      object: 'organization_membership',
+      organization_id: org.id,
+      user_id: userId,
+      role: { slug: 'member' },
+      status: 'active',
+      external_id: null,
+      metadata: {},
+    });
+    return org;
+  };
+
   const seedUser = (ws: ReturnType<typeof getWorkOSStore>, email: string, name: string | null = null) =>
     ws.users.insert({
       object: 'user',
@@ -2311,24 +2337,8 @@ describe('AuthKit interactive auth', () => {
   it('POST /user_management/authorize asks which organization when a user has several', async () => {
     const ws = getWorkOSStore(store);
     const user = seedUser(ws, 'multi@test.com');
-    for (const name of ['Acme', 'Beta']) {
-      const org = ws.organizations.insert({
-        object: 'organization',
-        name,
-        external_id: null,
-        stripe_customer_id: null,
-        metadata: {},
-      } as any);
-      ws.organizationMemberships.insert({
-        object: 'organization_membership',
-        user_id: user.id,
-        organization_id: org.id,
-        role: { slug: 'member' },
-        status: 'active',
-        external_id: null,
-        metadata: {},
-      } as any);
-    }
+    joinOrg(user.id, 'Acme');
+    joinOrg(user.id, 'Beta');
 
     const res = await app.request('/user_management/authorize', {
       method: 'POST',
@@ -2349,22 +2359,7 @@ describe('AuthKit interactive auth', () => {
   it('POST /user_management/authorize mints a code scoped to the chosen organization', async () => {
     const ws = getWorkOSStore(store);
     const user = seedUser(ws, 'multi2@test.com');
-    const chosen = ws.organizations.insert({
-      object: 'organization',
-      name: 'Chosen',
-      external_id: null,
-      stripe_customer_id: null,
-      metadata: {},
-    } as any);
-    ws.organizationMemberships.insert({
-      object: 'organization_membership',
-      user_id: user.id,
-      organization_id: chosen.id,
-      role: { slug: 'member' },
-      status: 'active',
-      external_id: null,
-      metadata: {},
-    } as any);
+    const chosen = joinOrg(user.id, 'Chosen');
 
     const res = await app.request('/user_management/authorize', {
       method: 'POST',
@@ -2384,13 +2379,7 @@ describe('AuthKit interactive auth', () => {
   it('POST /user_management/authorize refuses an organization the user is not in', async () => {
     const ws = getWorkOSStore(store);
     seedUser(ws, 'outsider@test.com');
-    const other = ws.organizations.insert({
-      object: 'organization',
-      name: 'Someone Else',
-      external_id: null,
-      stripe_customer_id: null,
-      metadata: {},
-    } as any);
+    const other = createOrg('Someone Else');
 
     const res = await app.request('/user_management/authorize', {
       method: 'POST',

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2200,6 +2200,23 @@ describe('AuthKit interactive auth', () => {
 
   const json = (res: Response) => res.json() as Promise<any>;
 
+  const seedUser = (ws: ReturnType<typeof getWorkOSStore>, email: string) =>
+    ws.users.insert({
+      object: 'user',
+      name: null,
+      email,
+      first_name: null,
+      last_name: null,
+      email_verified: false,
+      profile_picture_url: null,
+      last_sign_in_at: null,
+      external_id: null,
+      metadata: {},
+      locale: null,
+      password_hash: null,
+      impersonator: null,
+    });
+
   it('GET /user_management/authorize returns HTML login page', async () => {
     const ws = getWorkOSStore(store);
     ws.users.insert({
@@ -2225,6 +2242,93 @@ describe('AuthKit interactive auth', () => {
     expect(html).toContain('<form');
     expect(html).toContain('name="email"');
     expect(html).toContain('name="redirect_uri"');
+  });
+
+  it('POST /user_management/authorize asks which organization when a user has several', async () => {
+    const ws = getWorkOSStore(store);
+    const user = seedUser(ws, 'multi@test.com');
+    for (const name of ['Acme', 'Beta']) {
+      const org = ws.organizations.insert({
+        object: 'organization',
+        name,
+        external_id: null,
+        stripe_customer_id: null,
+        metadata: {},
+      } as any);
+      ws.organizationMemberships.insert({
+        object: 'organization_membership',
+        user_id: user.id,
+        organization_id: org.id,
+        role: { slug: 'member' },
+        status: 'active',
+        external_id: null,
+        metadata: {},
+      } as any);
+    }
+
+    const res = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ redirect_uri: 'http://localhost:3000/callback', email: 'multi@test.com' }),
+    });
+
+    // A page, not a redirect: production asks here rather than handing the client
+    // organization_selection_required at the exchange, which a browser cannot act on.
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Select an organization');
+    expect(html).toContain('name="organization_id"');
+    expect(html).toContain('Acme');
+    expect(html).toContain('Beta');
+  });
+
+  it('POST /user_management/authorize mints a code scoped to the chosen organization', async () => {
+    const ws = getWorkOSStore(store);
+    const user = seedUser(ws, 'multi2@test.com');
+    const chosen = ws.organizations.insert({
+      object: 'organization',
+      name: 'Chosen',
+      external_id: null,
+      stripe_customer_id: null,
+      metadata: {},
+    } as any);
+    ws.organizationMemberships.insert({
+      object: 'organization_membership',
+      user_id: user.id,
+      organization_id: chosen.id,
+      role: { slug: 'member' },
+      status: 'active',
+      external_id: null,
+      metadata: {},
+    } as any);
+
+    const res = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        redirect_uri: 'http://localhost:3000/callback',
+        email: 'multi2@test.com',
+        organization_id: chosen.id,
+      }),
+    });
+
+    expect(res.status).toBe(302);
+    const code = new URL(res.headers.get('location')!).searchParams.get('code')!;
+    expect(ws.authCodes.findOneBy('code', code)?.organization_id).toBe(chosen.id);
+  });
+
+  it('POST /user_management/authorize redirects straight through for a single-organization user', async () => {
+    const ws = getWorkOSStore(store);
+    seedUser(ws, 'single@test.com');
+
+    const res = await app.request('/user_management/authorize', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ redirect_uri: 'http://localhost:3000/callback', email: 'single@test.com' }),
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('code=');
   });
 
   it('GET /user_management/authorize pre-fills login_hint', async () => {

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -2200,10 +2200,10 @@ describe('AuthKit interactive auth', () => {
 
   const json = (res: Response) => res.json() as Promise<any>;
 
-  const seedUser = (ws: ReturnType<typeof getWorkOSStore>, email: string) =>
+  const seedUser = (ws: ReturnType<typeof getWorkOSStore>, email: string, name: string | null = null) =>
     ws.users.insert({
       object: 'user',
-      name: null,
+      name,
       email,
       first_name: null,
       last_name: null,
@@ -2242,6 +2242,70 @@ describe('AuthKit interactive auth', () => {
     expect(html).toContain('<form');
     expect(html).toContain('name="email"');
     expect(html).toContain('name="redirect_uri"');
+  });
+
+  it('GET /user_management/authorize offers the stored accounts as a picker', async () => {
+    const ws = getWorkOSStore(store);
+    seedUser(ws, 'alice@test.com', 'Alice Smith');
+    seedUser(ws, 'bob@test.com');
+
+    const res = await app.request('/user_management/authorize?redirect_uri=http://localhost:3000/callback');
+    const html = await res.text();
+
+    expect(html).toContain('<summary>Pick an account (2)</summary>');
+    // A submit button per account, so picking one posts that email directly. Named where a
+    // name is known, bare where it is not.
+    expect(html).toContain('name="email" value="alice@test.com"');
+    expect(html).toContain('Alice Smith');
+    expect(html).toContain('name="email" value="bob@test.com"');
+    // The free-text field is still there, so an unseeded address can still be typed.
+    expect(html).toContain('name="email"');
+    expect(html).toContain('type="email"');
+  });
+
+  it('GET /user_management/authorize lists accounts in email order', async () => {
+    const ws = getWorkOSStore(store);
+    // Inserted out of order, so store order and email order disagree.
+    seedUser(ws, 'zoe@test.com', 'Zoe Last');
+    seedUser(ws, 'alice@test.com', 'Alice First');
+    seedUser(ws, 'mo@test.com', 'Mo Middle');
+
+    const res = await app.request('/user_management/authorize?redirect_uri=http://localhost:3000/callback');
+    const html = await res.text();
+
+    const positions = ['alice@test.com', 'mo@test.com', 'zoe@test.com'].map((email) =>
+      html.indexOf(`value="${email}"`),
+    );
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it('GET /user_management/authorize lists a user created after startup', async () => {
+    const ws = getWorkOSStore(store);
+    seedUser(ws, 'seeded@test.com', 'Seeded User');
+
+    // A user created through the API mid-session, which is exactly the account someone testing a
+    // sign-up then wants to sign in as.
+    const created = await app.request('/user_management/users', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ email: 'later@test.com', first_name: 'Later', last_name: 'User' }),
+    });
+    expect(created.status).toBe(201);
+
+    const res = await app.request('/user_management/authorize?redirect_uri=http://localhost:3000/callback');
+    const html = await res.text();
+
+    expect(html).toContain('<summary>Pick an account (2)</summary>');
+    expect(html).toContain('name="email" value="later@test.com"');
+  });
+
+  it('GET /user_management/authorize omits the picker when the store is empty', async () => {
+    const res = await app.request('/user_management/authorize?redirect_uri=http://localhost:3000/callback');
+    const html = await res.text();
+
+    expect(html).not.toContain('<details');
+    expect(html).not.toContain('Pick an account');
   });
 
   it('POST /user_management/authorize asks which organization when a user has several', async () => {

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -605,16 +605,27 @@ export function authRoutes(ctx: RouteContext): void {
           );
         }
         // A code outlives the membership that justified it easily enough: ten minutes is long
-        // enough for one to be deactivated or deleted in between. Trusting the stored
-        // organization would issue a session, tokens, a role and permissions for an
-        // organization the user no longer actively belongs to, so it is dropped and the
-        // resolution below runs as though the code had never carried one, which is what every
-        // other grant does.
-        organizationId =
+        // enough for one to be revoked in between. Neither obvious response is right. Trusting
+        // the stored organization issues a session, tokens, a role and permissions for one the
+        // user no longer belongs to. Clearing it and re-resolving is worse in a quieter way: a
+        // user left with exactly one other membership is signed into that tenant instead,
+        // without being told, having picked the first.
+        //
+        // So the grant fails. Its premise is gone, and the client's move is to authorize again,
+        // where the selection page shows what is actually available now. Worded like the other
+        // invalid-code failures rather than naming the membership, since the caller is
+        // unauthenticated at this point and the distinction is not theirs to learn.
+        if (
           authCode.organization_id &&
-          activeOrganizationsFor(authCode.user_id).some((o) => o.id === authCode.organization_id)
-            ? authCode.organization_id
-            : null;
+          !activeOrganizationsFor(authCode.user_id).some((o) => o.id === authCode.organization_id)
+        ) {
+          failAuth(
+            'OAuth',
+            { userId: authCode.user_id, email: ws.users.get(authCode.user_id)?.email },
+            new OauthApiError(400, 'invalid_grant', `The code '${code}' has expired or is invalid.`),
+          );
+        }
+        organizationId = authCode.organization_id;
         // Bind the token's client_id to the authorization grant, not the unvalidated
         // redemption-time request parameter.
         grantClientId = authCode.client_id ?? undefined;

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -604,7 +604,17 @@ export function authRoutes(ctx: RouteContext): void {
             new OauthApiError(400, 'invalid_grant', `The code '${code}' has expired or is invalid.`),
           );
         }
-        organizationId = authCode.organization_id;
+        // A code outlives the membership that justified it easily enough: ten minutes is long
+        // enough for one to be deactivated or deleted in between. Trusting the stored
+        // organization would issue a session, tokens, a role and permissions for an
+        // organization the user no longer actively belongs to, so it is dropped and the
+        // resolution below runs as though the code had never carried one, which is what every
+        // other grant does.
+        organizationId =
+          authCode.organization_id &&
+          activeOrganizationsFor(authCode.user_id).some((o) => o.id === authCode.organization_id)
+            ? authCode.organization_id
+            : null;
         // Bind the token's client_id to the authorization grant, not the unvalidated
         // redemption-time request parameter.
         grantClientId = authCode.client_id ?? undefined;

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -112,6 +112,18 @@ export function authRoutes(ctx: RouteContext): void {
       return c.redirect(redirect.toString());
     }
 
+    // A caller-supplied organization only means anything if the user is actually in it. Minting
+    // a code for one they are not a member of would put that org_id on the token with no role or
+    // permissions behind it, which is a session no membership justifies and, for anything
+    // authorizing on org_id, the wrong tenant entirely.
+    if (organizationId && !activeOrganizationsFor(user.id).some((o) => o.id === organizationId)) {
+      throw new WorkOSApiError(
+        400,
+        `User is not an active member of organization ${organizationId}`,
+        'invalid_request',
+      );
+    }
+
     // Hosted AuthKit asks which organization here, before it mints anything, so the client's
     // exchange always succeeds. Resolving it at the exchange instead would answer a browser
     // client with organization_selection_required, which it cannot act on mid-callback.

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -174,6 +174,7 @@ export function authRoutes(ctx: RouteContext): void {
     const codeChallengeMethod = url.searchParams.get('code_challenge_method');
     const loginHint = url.searchParams.get('login_hint');
     const clientId = url.searchParams.get('client_id');
+    const organizationId = url.searchParams.get('organization_id');
 
     if (!redirectUri) {
       throw new WorkOSApiError(400, 'redirect_uri is required', 'invalid_request');
@@ -191,6 +192,9 @@ export function authRoutes(ctx: RouteContext): void {
       if (codeChallenge) hiddenFields.code_challenge = codeChallenge;
       if (codeChallengeMethod) hiddenFields.code_challenge_method = codeChallengeMethod;
       if (clientId) hiddenFields.client_id = clientId;
+      // Carried through the login page so a caller that already knows the organization skips
+      // the selection page after the POST, rather than losing the GET's pre-selection here.
+      if (organizationId) hiddenFields.organization_id = organizationId;
 
       return c.html(
         renderLoginPage({
@@ -214,7 +218,7 @@ export function authRoutes(ctx: RouteContext): void {
       codeChallengeMethod,
       loginHint,
       clientId,
-      organizationId: url.searchParams.get('organization_id'),
+      organizationId,
     });
   });
 

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -33,7 +33,7 @@ import { renderConfiguredJwtTemplate } from '../jwt-template.js';
 import type { EventBus } from '../event-bus.js';
 import type { WorkOSInvitation, WorkOSSSOAuthorization, WorkOSUser } from '../entities.js';
 import { STORE_KEYS, STORE_KEY_PREFIXES } from '../constants.js';
-import { renderLoginPage, renderDeviceVerifyPage } from '../login-page.js';
+import { renderLoginPage, renderDeviceVerifyPage, renderOrganizationSelectPage } from '../login-page.js';
 
 interface PendingAuth {
   user_id: string;
@@ -62,14 +62,30 @@ interface AuthorizeParams {
   codeChallengeMethod: string | null;
   loginHint: string | null;
   clientId: string | null;
+  /** Which organization the session should be scoped to, when the caller already knows. */
+  organizationId: string | null;
 }
 
 export function authRoutes(ctx: RouteContext): void {
   const { app, store, jwt } = ctx;
   const ws = getWorkOSStore(store);
 
+  /**
+   * The organizations a session could be scoped to. 'pending' is an unaccepted invitation and
+   * 'inactive' a deactivated member; neither is one production would scope a session to.
+   */
+  function activeOrganizationsFor(userId: string): Array<{ id: string; name: string }> {
+    const orgs: Array<{ id: string; name: string }> = [];
+    for (const m of ws.organizationMemberships.findBy('user_id', userId)) {
+      if (m.status !== 'active') continue;
+      const org = ws.organizations.get(m.organization_id);
+      if (org) orgs.push({ id: org.id, name: org.name });
+    }
+    return orgs;
+  }
+
   function resolveAndRedirect(c: any, params: AuthorizeParams) {
-    const { redirectUri, state, codeChallenge, codeChallengeMethod, loginHint, clientId } = params;
+    const { redirectUri, state, codeChallenge, codeChallengeMethod, loginHint, clientId, organizationId } = params;
 
     assertAllowedRedirectUri(redirectUri, store);
 
@@ -96,9 +112,34 @@ export function authRoutes(ctx: RouteContext): void {
       return c.redirect(redirect.toString());
     }
 
+    // Hosted AuthKit asks which organization here, before it mints anything, so the client's
+    // exchange always succeeds. Resolving it at the exchange instead would answer a browser
+    // client with organization_selection_required, which it cannot act on mid-callback.
+    // Interactive only: a headless caller drives the documented API and handles that response
+    // itself, and this is the one mode that can put a page in front of a human.
+    if (!organizationId && store.getData<boolean>(STORE_KEYS.interactiveAuth)) {
+      const selectable = activeOrganizationsFor(user.id);
+      if (selectable.length > 1) {
+        const hiddenFields: Record<string, string> = { redirect_uri: redirectUri, email: user.email };
+        if (state) hiddenFields.state = state;
+        if (codeChallenge) hiddenFields.code_challenge = codeChallenge;
+        if (codeChallengeMethod) hiddenFields.code_challenge_method = codeChallengeMethod;
+        if (clientId) hiddenFields.client_id = clientId;
+
+        return c.html(
+          renderOrganizationSelectPage({
+            email: user.email,
+            organizations: selectable,
+            formAction: '/user_management/authorize',
+            hiddenFields,
+          }),
+        );
+      }
+    }
+
     const authCode = ws.authCodes.insert({
       user_id: user.id,
-      organization_id: null,
+      organization_id: organizationId,
       code: generateId('auth_code'),
       redirect_uri: redirectUri,
       expires_at: expiresIn(10),
@@ -150,7 +191,15 @@ export function authRoutes(ctx: RouteContext): void {
       );
     }
 
-    return resolveAndRedirect(c, { redirectUri, state, codeChallenge, codeChallengeMethod, loginHint, clientId });
+    return resolveAndRedirect(c, {
+      redirectUri,
+      state,
+      codeChallenge,
+      codeChallengeMethod,
+      loginHint,
+      clientId,
+      organizationId: url.searchParams.get('organization_id'),
+    });
   });
 
   app.post('/user_management/authorize', async (c) => {
@@ -167,6 +216,7 @@ export function authRoutes(ctx: RouteContext): void {
       codeChallengeMethod: (form.code_challenge_method as string) ?? null,
       loginHint: (form.email as string) ?? null,
       clientId: (form.client_id as string) ?? null,
+      organizationId: (form.organization_id as string) ?? null,
     });
   });
 
@@ -903,14 +953,7 @@ export function authRoutes(ctx: RouteContext): void {
     // refresh is excluded: it reuses a session whose scope is already settled, and an explicit
     // body.organization_id stays the only way to move an existing session between orgs.
     if (isFreshLogin && !organizationId) {
-      const selectableOrgs: Array<{ id: string; name: string }> = [];
-      for (const m of ws.organizationMemberships.findBy('user_id', user.id)) {
-        // 'pending' is an unaccepted invitation and 'inactive' a deactivated member; neither is
-        // an organization production would scope a session to.
-        if (m.status !== 'active') continue;
-        const org = ws.organizations.get(m.organization_id);
-        if (org) selectableOrgs.push({ id: org.id, name: org.name });
-      }
+      const selectableOrgs = activeOrganizationsFor(user.id);
 
       if (selectableOrgs.length === 1) {
         organizationId = selectableOrgs[0].id;

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -187,6 +187,10 @@ export function authRoutes(ctx: RouteContext): void {
           emailHint: loginHint ?? undefined,
           formAction: '/user_management/authorize',
           hiddenFields,
+          // Every user the emulator holds, seeded or created through the API since; the page
+          // sorts them. Behind --interactive, and the same list is already readable from
+          // GET /user_management/users, so this discloses nothing it did not already hand out.
+          users: ws.users.all().map((u) => ({ email: u.email, name: u.name })),
         }),
       );
     }


### PR DESCRIPTION
Two commits, separable if you would rather take only the first.

## 1. A multi-organization user cannot finish an interactive sign-in

The organization is resolved at the token exchange, so a user with more than one active membership gets `organization_selection_required` back from `/user_management/authenticate`. That is an API-level response, and a browser client receives it in the middle of its callback with no way to act on it. Against `@workos-inc/authkit-react` it surfaces as a `CodeExchangeError` and the app shows a generic failure, in our case "This sign-in link has already been used or has expired", which is not what happened.

<img width="3024" height="1570" alt="image" src="https://github.com/user-attachments/assets/1d1dadda-c38c-454a-b9dd-afadca9c929f" />

Reproduced on 0.8.0 with `--interactive`:

```
POST /user_management/authorize   (email=multi@example.test)  -> 302 ...?code=auth_code_01…
POST /user_management/authenticate (authorization_code)       -> 403 organization_selection_required
                                                                  { organizations: [Acme, Beta], pending_authentication_token: … }
```

Hosted AuthKit asks **before** it mints a code, so the code carries the organization and the exchange simply succeeds. This adds that step: interactive authorize renders a selection page, one row per active membership, when a user belongs to several.

`/authorize` also accepts `organization_id`, which the selection page posts back. To be straight about it: the parameter exists on [the documented endpoint](https://workos.com/docs/reference/authkit/authentication/get-authorization-url), but it is documented for routing SSO to the right connection, and using it to pre-select the session's organization is my reading rather than something the docs state. Say the word if you would rather that half arrived under a different name, or not at all — the selection page is the part that matters and it could post an internal field instead.

It is validated against the user's active memberships and refused with a 400 otherwise. Without that check a POST could scope a session to any organization, including one that does not exist, and the token then carried that `org_id` with a null role behind it, which points anything authorizing on `org_id` at the wrong tenant.

Deliberately scoped:

- **Interactive only.** A headless caller drives the documented API and handles `organization_selection_required` itself, which is the correct contract and is untouched.
- Single-membership users still redirect straight through.
- The grant-side resolution now shares the same active-membership helper, so both paths agree on what is selectable.

## 2. An account picker on the sign-in page

The page asks for an email and nothing else, so signing in as a particular seeded user means remembering the exact address of each one. This offers them beneath the field, collapsed behind a disclosure that expands to one row per account.

<img width="3024" height="1570" alt="image" src="https://github.com/user-attachments/assets/90515318-dd7e-46a3-be9a-e9a7da14032f" />

<img width="3024" height="1570" alt="image" src="https://github.com/user-attachments/assets/119eb16f-0ac9-4005-aa9e-56f6ad78d14b" />

- **Collapsed by default**, so the page an unknown address or a sign-up arrives at is unchanged.
- **Flat, not grouped by organization**, because the emulator now asks which organization in its own step and grouping here would imply a choice this page does not make.
- **Every account, not only seeded ones**: a user created through the API mid-session appears too, which is the account someone testing a sign-up then wants to sign in as.
- **Ordered by email.** Store order put the most recently created at the bottom and moved rows under the reader. By email rather than name because a name is optional.
- **No JavaScript.** Each row is a submit button and `<details>` does the expanding, matching the page as it stands. The list scrolls at a fixed height rather than growing the card.
- The free-text field is untouched, so an unseeded address still signs in, and an emulator with no users renders exactly as before.

## Two things worth your judgement

- **The picker lists every account's email on an unauthenticated page.** It is behind `--interactive`, and the same list is already readable from `GET /user_management/users` with the default key, so it discloses nothing new. Happy to put it behind its own flag if you would rather it were opt-in.
- **No cap on the list.** A store with a thousand users renders a thousand rows into the page; they scroll rather than stretching the card, but the HTML grows. I left it uncapped rather than silently truncating, on the grounds that a truncated list reads as complete. A cap with a "showing N of M" line is easy to add if you prefer.

## Testing

`bun test` 900 pass, 0 fail. `typecheck`, `oxlint` and `oxfmt --check` clean. Eight new tests cover the selection page, the code being scoped to the chosen organization, an organization the user is not a member of being refused, one that does not exist being refused, single-membership users redirecting through, the picker's contents and ordering, an account created after startup appearing, and the page being unchanged when the store is empty. The existing test that pins `organization_selection_required` for the headless password grant still passes, which is the contract this deliberately leaves alone.

Also driven end to end in a browser against a real application using `authkit-react`: sign in from the picker, land in the app; sign in as a multi-organization user, choose, and land in the chosen organization with the expected `org_id` on the token.

## Notes

- Wording follows the codebase's `organization`, though hosted AuthKit renders "Select an organisation to continue" in some locales.
- Happy to split this into two PRs if you would rather review the fix on its own; they touch adjacent parts of `login-page.ts`, which is the only reason they are together.

