### PR TITLE
feat(sso): serve OIDC discovery per AuthKit client

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,10 +803,12 @@ What this buys you:
 
 - **OIDC discovery.** `GET /user_management/:client_id/.well-known/openid-configuration` serves the
   same document production does, unauthenticated, so a client that discovers its endpoints rather
-  than hard-coding them needs no emulator-specific branch. One deliberate difference: `issuer` is
-  the emulator's configured issuer, not production's `{base}/user_management/{client_id}`, because
-  it has to match the `iss` the emulator actually mints or a client validating one against the
-  other rejects every token.
+  than hard-coding them needs no emulator-specific branch. The endpoints follow the host the
+  document was fetched over, so reaching the emulator as `host.docker.internal` or a service name
+  gets a document pointing back at that name rather than at localhost. One deliberate difference:
+  `issuer` is the emulator's configured issuer, not production's
+  `{base}/user_management/{client_id}`, because it has to match the `iss` the emulator actually
+  mints or a client validating one against the other rejects every token.
 - **JWKS stable across restarts.** `/sso/jwks/:client_id` publishes the same key every boot, so a
   token minted before a restart still verifies after it. Without a pinned key, a verifier that
   cached the JWKS must refetch.

--- a/README.md
+++ b/README.md
@@ -771,9 +771,9 @@ rather than replaying the login.
 
 ## Stable Signing Key and Issuer
 
-By default the emulator generates an RSA keypair at startup and mints its own URL as `iss`. That is
-fine for a single run, but it means a restart invalidates every token already issued and changes the
-published JWKS — and the issuer moves with the port.
+By default the emulator generates an RSA keypair at startup and builds `iss` from its own URL. That
+is fine for a single run, but it means a restart invalidates every token already issued and changes
+the published JWKS — and the issuer moves with the port.
 
 Pin either or both to make tokens outlive a restart:
 
@@ -801,14 +801,6 @@ const emulator = await createEmulator({
 
 What this buys you:
 
-- **OIDC discovery.** `GET /user_management/:client_id/.well-known/openid-configuration` serves the
-  same document production does, unauthenticated, so a client that discovers its endpoints rather
-  than hard-coding them needs no emulator-specific branch. The endpoints follow the host the
-  document was fetched over, so reaching the emulator as `host.docker.internal` or a service name
-  gets a document pointing back at that name rather than at localhost. One deliberate difference:
-  `issuer` is the emulator's configured issuer, not production's
-  `{base}/user_management/{client_id}`, because it has to match the `iss` the emulator actually
-  mints or a client validating one against the other rejects every token.
 - **JWKS stable across restarts.** `/sso/jwks/:client_id` publishes the same key every boot, so a
   token minted before a restart still verifies after it. Without a pinned key, a verifier that
   cached the JWKS must refetch.
@@ -818,12 +810,61 @@ What this buys you:
 - **One key across several emulators**, or tokens pre-signed offline with the same key the emulator
   verifies.
 
+`--issuer` is the base the client id hangs off, not the whole claim. An AuthKit access token from
+`/user_management/authenticate` carries `iss` of `{issuer}/user_management/{client_id}`, which is
+what production mints — so `--issuer https://api.workos.com` with a client of `client_123` gives
+`https://api.workos.com/user_management/client_123`. Only the M2M, SSO and widget tokens carry the
+bare value.
+
 The key must be a PEM-encoded RSA private key, since tokens are signed RS256; anything else fails at
 startup with a message saying why. Omit `--kid` and the `kid` is derived from the key itself, so it
 is stable for a pinned key without being pinned separately.
 
 > A pinned signing key is a test fixture, not a secret to reuse anywhere real. Never point the
 > emulator at a key your production environment trusts.
+
+## OIDC Discovery
+
+`GET /user_management/:client_id/.well-known/openid-configuration` serves the same document
+production does, unauthenticated, so a client that discovers its endpoints rather than hard-coding
+them needs no emulator-specific branch:
+
+```bash
+curl http://localhost:4100/user_management/client_123/.well-known/openid-configuration
+```
+
+```json
+{
+  "issuer": "http://localhost:4100/user_management/client_123",
+  "authorization_endpoint": "http://localhost:4100/user_management/authorize",
+  "token_endpoint": "http://localhost:4100/user_management/authenticate",
+  "response_types_supported": ["code"],
+  "jwks_uri": "http://localhost:4100/sso/jwks/client_123"
+}
+```
+
+Those five fields are the whole document production returns. `subject_types_supported` and
+`id_token_signing_alg_values_supported` are absent from both, though OIDC Discovery marks them
+required — a client that needs them fails against WorkOS too, and an emulator that papered over
+that would be hiding the failure rather than reproducing it.
+
+The endpoints follow the host the document was fetched over, so reaching the emulator as
+`host.docker.internal` or a compose service name gets a document pointing back at that name rather
+than at localhost. `issuer` is the one field that does not: it has to equal the `iss` the emulator
+mints, whatever name the document was fetched under. If a strict client enforces OIDC Discovery
+§4.3 — `issuer` must equal the URL the document was fetched from — and you reach the emulator under
+a name other than its own base URL, set `--issuer` to that name.
+
+An id that is not shaped like a client id gets production's 404 rather than a document advertising
+it as a key endpoint:
+
+```json
+{ "message": "Application not found: 'nope'.", "code": "entity_not_found", "entity_id": "nope" }
+```
+
+A _registered_ client cannot be told apart from an unregistered one — nothing under
+`/user_management` or `/sso` consults the application registry, so `authorize` and `/sso/jwks` serve
+any well-formed id too.
 
 ## Redirect URI Hosts
 

--- a/README.md
+++ b/README.md
@@ -801,6 +801,12 @@ const emulator = await createEmulator({
 
 What this buys you:
 
+- **OIDC discovery.** `GET /user_management/:client_id/.well-known/openid-configuration` serves the
+  same document production does, unauthenticated, so a client that discovers its endpoints rather
+  than hard-coding them needs no emulator-specific branch. One deliberate difference: `issuer` is
+  the emulator's configured issuer, not production's `{base}/user_management/{client_id}`, because
+  it has to match the `iss` the emulator actually mints or a client validating one against the
+  other rejects every token.
 - **JWKS stable across restarts.** `/sso/jwks/:client_id` publishes the same key every boot, so a
   token minted before a restart still verifies after it. Without a pinned key, a verifier that
   cached the JWKS must refetch.

--- a/README.md
+++ b/README.md
@@ -813,8 +813,9 @@ What this buys you:
 `--issuer` is the base the client id hangs off, not the whole claim. An AuthKit access token from
 `/user_management/authenticate` carries `iss` of `{issuer}/user_management/{client_id}`, which is
 what production mints — so `--issuer https://api.workos.com` with a client of `client_123` gives
-`https://api.workos.com/user_management/client_123`. Only the M2M, SSO and widget tokens carry the
-bare value.
+`https://api.workos.com/user_management/client_123`. The M2M, SSO and widget tokens carry the bare
+value, as does an AuthKit token from a grant that named no `client_id` — there is no client to hang
+off, and inventing a placeholder would advertise an issuer whose discovery document is not there.
 
 The key must be a PEM-encoded RSA private key, since tokens are signed RS256; anything else fails at
 startup with a message saying why. Omit `--kid` and the `kid` is derived from the key itself, so it

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,9 @@ Options:
                       it a key is generated at startup, so the published JWKS changes on
                       every restart. Pin it to keep the JWKS stable.
   --kid <id>          Key id to advertise in the JWKS (default: derived from the key)
-  --issuer <url>      Value to mint as the "iss" claim (default: the emulator's own URL)
+  --issuer <url>      Base the "iss" claim is built from (default: the emulator's own URL).
+                      An AuthKit token carries <url>/user_management/<client_id>, as
+                      production does; M2M, SSO and widget tokens carry <url> itself.
   --redirect-hosts <hosts>
                       Comma-separated hosts a redirect_uri may point at, on top of localhost
                       (always allowed). Use for test environments with production-like

--- a/src/core/jwt.spec.ts
+++ b/src/core/jwt.spec.ts
@@ -33,6 +33,19 @@ describe('JWTManager', () => {
     expect(payload.exp).toBe(payload.iat + 3600);
   });
 
+  it('strips a trailing slash from the issuer, however it was set', () => {
+    // `authKitIssuer` concatenates, so a trailing slash would mint
+    // `https://api.workos.com//user_management/client_01XYZ` — a URL production never emits and
+    // no verifier is comparing against. Easy to hand it one from a compose file or an env var.
+    const pinned = new JWTManager('https://api.workos.com/');
+    expect(pinned.issuer).toBe('https://api.workos.com');
+    expect(pinned.authKitIssuer('client_01XYZ')).toBe('https://api.workos.com/user_management/client_01XYZ');
+
+    // createEmulator reassigns it after listen() resolves an ephemeral port; that path normalizes too.
+    pinned.issuer = 'https://api.workos.com//';
+    expect(pinned.authKitIssuer('client_01XYZ')).toBe('https://api.workos.com/user_management/client_01XYZ');
+  });
+
   it('preserves optional fields like role and permissions', () => {
     const token = jwt.sign({
       sub: 'user_01ABC',

--- a/src/core/jwt.ts
+++ b/src/core/jwt.ts
@@ -64,6 +64,13 @@ interface SignOptions {
    * is not something a template gets to restate.
    */
   claims?: Record<string, unknown>;
+  /**
+   * AuthKit client to scope `iss` to, giving the per-client issuer production mints for
+   * `/user_management/authenticate` tokens. Omit and `iss` is the bare configured issuer,
+   * which is what the M2M, SSO and widget tokens want — none of them is the token the
+   * AuthKit discovery document describes.
+   */
+  issuerClientId?: string;
 }
 
 export interface SigningKeyOptions {
@@ -143,6 +150,26 @@ export class JWTManager {
     this.kid = signingKey?.kid ?? `workos_emulate_${jwkThumbprint(this.publicKey).slice(0, 16)}`;
   }
 
+  /**
+   * The `iss` of an AuthKit access token, and the `issuer` its OIDC discovery document
+   * advertises — one function so the two cannot drift.
+   *
+   * Production derives it from the environment's client id, not the bare API URL:
+   * `${apiUrl}/user_management/${clientId}` (`getIssuer` in
+   * `api-services/src/jwt-claims/build-access-token-claims.ts`, under the default
+   * `issuerType: 'ClientId'`). Its `'Legacy'` issuer type returns the bare URL instead —
+   * what the emulator used to mint for every token — so a verifier written against a
+   * current WorkOS environment saw an `iss` it would have rejected in production.
+   *
+   * It also makes the discovery document valid: OIDC Discovery 1.0 §4.3 requires `issuer`
+   * to equal the URL prefix the document was fetched from, and that prefix carries the
+   * client id. Reach the emulator under a name other than its configured base URL and the
+   * two diverge again — set `--issuer` to that name if a client enforces §4.3.
+   */
+  authKitIssuer(clientId: string): string {
+    return `${this.issuer}/user_management/${clientId}`;
+  }
+
   sign(payload: Omit<JWTClaims, 'iss' | 'iat' | 'exp'>, options?: SignOptions): string {
     const now = Math.floor(Date.now() / 1000);
     const expiresIn = options?.expiresIn ?? 3600;
@@ -159,7 +186,7 @@ export class JWTManager {
       // reserved claims below are off-limits, so a template may deliberately restate `role`,
       // `permissions`, or `org_id`.
       ...templateClaims,
-      iss: this.issuer,
+      iss: options?.issuerClientId ? this.authKitIssuer(options.issuerClientId) : this.issuer,
       iat: now,
       exp: now + expiresIn,
     };

--- a/src/core/jwt.ts
+++ b/src/core/jwt.ts
@@ -130,7 +130,22 @@ export class JWTManager {
   private privateKey: KeyObject;
   private publicKey: KeyObject;
   private kid: string;
-  issuer: string;
+  private _issuer = '';
+
+  /**
+   * Base the `iss` claim is built from. Trailing slashes are stripped on the way in, whichever
+   * way it is set, because `authKitIssuer` concatenates: `--issuer https://api.workos.com/`
+   * would otherwise mint `https://api.workos.com//user_management/client_x`, which equals
+   * nothing production emits and nothing a verifier is comparing against. Settable because
+   * `createEmulator` learns the bound URL only after listen() resolves an ephemeral port.
+   */
+  get issuer(): string {
+    return this._issuer;
+  }
+
+  set issuer(value: string) {
+    this._issuer = value.replace(/\/+$/, '');
+  }
 
   constructor(issuer = 'https://api.workos.com', signingKey?: SigningKeyOptions) {
     this.issuer = issuer;

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -70,11 +70,16 @@ export function createServer(plugin: ServicePlugin, options: ServerOptions = {})
     '/_emulate/',
   ];
 
+  // OIDC discovery is per AuthKit client, so the path carries an id and cannot be matched
+  // exactly. Public upstream, since a client fetches it before it holds any credential.
+  const OPENID_CONFIGURATION = /^\/user_management\/[^/]+\/\.well-known\/openid-configuration$/;
+
   app.use('*', async (c, next) => {
     const path = new URL(c.req.url).pathname;
 
     // Skip auth for public paths
     if (PUBLIC_PATHS.has(path)) return next();
+    if (OPENID_CONFIGURATION.test(path)) return next();
     for (const prefix of PUBLIC_PATH_PREFIXES) {
       if (path.startsWith(prefix)) {
         // data-integrations: only /authorize subpath is public

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -12,9 +12,12 @@ export interface ServerOptions {
   baseUrl?: string;
   apiKeys?: ApiKeyMap;
   /**
-   * `iss` to mint into tokens. Defaults to the emulator's own base URL. Pin it to match
-   * what your real WorkOS environment emits, so a verifier that checks `iss` against a
+   * Base the `iss` claim is built from. Defaults to the emulator's own base URL. Pin it to the
+   * URL your real WorkOS environment issues from, so a verifier that checks `iss` against a
    * constant accepts emulator tokens unchanged.
+   *
+   * Not the whole claim: an AuthKit access token carries `{issuer}/user_management/{client_id}`,
+   * as production does. Only the M2M, SSO and widget tokens carry the bare value.
    */
   issuer?: string;
   /** Pinned RSA signing key, keeping the JWKS stable across restarts. */
@@ -71,8 +74,10 @@ export function createServer(plugin: ServicePlugin, options: ServerOptions = {})
   ];
 
   // OIDC discovery is per AuthKit client, so the path carries an id and cannot be matched
-  // exactly. Public upstream, since a client fetches it before it holds any credential.
-  const OPENID_CONFIGURATION = /^\/user_management\/[^/]+\/\.well-known\/openid-configuration$/;
+  // exactly. Public upstream, since a client fetches it before it holds any credential. The
+  // trailing slash is allowed through too: the route itself does not match it, and a 404 saying
+  // the document is not there beats a 401 that reads as a credential the caller could fix.
+  const OPENID_CONFIGURATION = /^\/user_management\/[^/]+\/\.well-known\/openid-configuration\/?$/;
 
   app.use('*', async (c, next) => {
     const path = new URL(c.req.url).pathname;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,10 +53,13 @@ export interface EmulatorOptions {
   hostname?: string;
   seed?: EmulatorSeedConfig;
   /**
-   * `iss` to mint into access tokens, and to advertise as the OIDC issuer. Defaults to the
-   * emulator's own URL, which changes with the port. Pin it to the issuer your real WorkOS
-   * environment emits so a verifier comparing `iss` against a constant needs no test-only
-   * branch. The verifier must still fetch JWKS from the emulator.
+   * Base the `iss` claim is built from, and the base of the OIDC issuer discovery advertises.
+   * Defaults to the emulator's own URL, which changes with the port. Pin it to the URL your real
+   * WorkOS environment issues from so a verifier comparing `iss` against a constant needs no
+   * test-only branch. The verifier must still fetch JWKS from the emulator.
+   *
+   * Not the whole claim: an AuthKit access token carries `{issuer}/user_management/{client_id}`,
+   * as production does. Only the M2M, SSO and widget tokens carry the bare value.
    */
   issuer?: string;
   /**

--- a/src/workos/jwt-template-integration.spec.ts
+++ b/src/workos/jwt-template-integration.spec.ts
@@ -377,7 +377,7 @@ describe('Pinned signing key and issuer', () => {
     expect((await jwks(emulator.url)).keys[0].kid).toBe('ci_key');
   });
 
-  it('mints a pinned issuer instead of the emulator URL', async () => {
+  it('scopes a pinned issuer to the client, as production does, instead of the emulator URL', async () => {
     emulator = await createEmulator({
       port: 0,
       issuer: 'https://api.workos.com',
@@ -397,10 +397,13 @@ describe('Pinned signing key and issuer', () => {
     });
     const body = (await res.json()) as any;
     const claims = JSON.parse(Buffer.from(body.access_token.split('.')[1], 'base64url').toString('utf-8'));
-    expect(claims.iss).toBe('https://api.workos.com');
+    // `--issuer` is the base the client id hangs off, matching production's `getIssuer`:
+    // `${apiUrl}/user_management/${clientId}` under the default `issuerType: 'ClientId'`. Pinning
+    // it to the bare API URL was minting production's non-default `'Legacy'` shape.
+    expect(claims.iss).toBe('https://api.workos.com/user_management/client_test');
   });
 
-  it('defaults the issuer to the emulator URL', async () => {
+  it('defaults the issuer base to the emulator URL', async () => {
     emulator = await createEmulator({
       port: 0,
       seed: { users: [{ email: 'alice@acme.com', password: 'test123', email_verified: true }] },
@@ -419,6 +422,6 @@ describe('Pinned signing key and issuer', () => {
     });
     const body = (await res.json()) as any;
     const claims = JSON.parse(Buffer.from(body.access_token.split('.')[1], 'base64url').toString('utf-8'));
-    expect(claims.iss).toBe(emulator.url);
+    expect(claims.iss).toBe(`${emulator.url}/user_management/client_test`);
   });
 });

--- a/src/workos/jwt-template-integration.spec.ts
+++ b/src/workos/jwt-template-integration.spec.ts
@@ -424,4 +424,28 @@ describe('Pinned signing key and issuer', () => {
     const claims = JSON.parse(Buffer.from(body.access_token.split('.')[1], 'base64url').toString('utf-8'));
     expect(claims.iss).toBe(`${emulator.url}/user_management/client_test`);
   });
+
+  it('mints the bare issuer when the grant binds no client, rather than inventing one', async () => {
+    emulator = await createEmulator({
+      port: 0,
+      issuer: 'https://api.workos.com',
+      seed: { users: [{ email: 'alice@acme.com', password: 'test123', email_verified: true }] },
+    });
+
+    const res = await fetch(`${emulator.url}/user_management/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // No client_id: the emulator accepts the grant, and `aud` falls back to a placeholder.
+      body: JSON.stringify({ grant_type: 'password', email: 'alice@acme.com', password: 'test123' }),
+    });
+    const body = (await res.json()) as any;
+    const claims = JSON.parse(Buffer.from(body.access_token.split('.')[1], 'base64url').toString('utf-8'));
+
+    // `aud`'s placeholder must not reach `iss`: scoping it would mint
+    // `https://api.workos.com/user_management/workos-emulate`, an issuer whose discovery document
+    // 404s, so a client discovering from `iss` would follow it nowhere. The bare issuer is at
+    // least a real value, and production's `'Legacy'` shape.
+    expect(claims.aud).toBe('workos-emulate');
+    expect(claims.iss).toBe('https://api.workos.com');
+  });
 });

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -1104,9 +1104,11 @@ export function authRoutes(ctx: RouteContext): void {
     // Prefer the client_id bound to the originating grant (auth code or refresh token)
     // over the unvalidated redemption-time request parameter.
     const tokenClientId = grantClientId ?? clientId;
-    // Both `aud` and the client id `iss` is scoped to, so the token agrees with the discovery
-    // document fetched for that client. Falls back with `aud` rather than separately: an issuer
-    // naming one client and an audience naming another would be worse than either.
+    // `aud` keeps its placeholder when no client is bound; `iss` does not get one. A grant with
+    // no client_id would otherwise mint `{issuer}/user_management/workos-emulate`, an issuer URL
+    // whose discovery document 404s — production mints no such thing, and a client discovering
+    // from `iss` would follow it nowhere. Absent a client, `iss` is the bare configured issuer,
+    // which is a real value and production's `'Legacy'` shape.
     const tokenAudience = tokenClientId ?? 'workos-emulate';
 
     // Entitlements and feature flags re-resolve at every mint — including refresh grants — so
@@ -1138,7 +1140,7 @@ export function authRoutes(ctx: RouteContext): void {
         feature_flags: flagSlugs.length ? flagSlugs : undefined,
         aud: tokenAudience,
       },
-      { claims: templateClaims, issuerClientId: tokenAudience },
+      { claims: templateClaims, issuerClientId: tokenClientId },
     );
 
     // Store a real refresh token

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -1104,6 +1104,10 @@ export function authRoutes(ctx: RouteContext): void {
     // Prefer the client_id bound to the originating grant (auth code or refresh token)
     // over the unvalidated redemption-time request parameter.
     const tokenClientId = grantClientId ?? clientId;
+    // Both `aud` and the client id `iss` is scoped to, so the token agrees with the discovery
+    // document fetched for that client. Falls back with `aud` rather than separately: an issuer
+    // naming one client and an audience naming another would be worse than either.
+    const tokenAudience = tokenClientId ?? 'workos-emulate';
 
     // Entitlements and feature flags re-resolve at every mint — including refresh grants — so
     // a plan change or flag toggle lands in the next token. Both claims are omitted rather
@@ -1132,9 +1136,9 @@ export function authRoutes(ctx: RouteContext): void {
         act: updatedUser.impersonator ? { sub: updatedUser.impersonator.email } : undefined,
         entitlements: entitlements?.length ? entitlements : undefined,
         feature_flags: flagSlugs.length ? flagSlugs : undefined,
-        aud: tokenClientId ?? 'workos-emulate',
+        aud: tokenAudience,
       },
-      { claims: templateClaims },
+      { claims: templateClaims, issuerClientId: tokenAudience },
     );
 
     // Store a real refresh token

--- a/src/workos/routes/sso.spec.ts
+++ b/src/workos/routes/sso.spec.ts
@@ -628,6 +628,34 @@ describe('OIDC discovery', () => {
     expect(body.jwks_uri).toMatch(/\/sso\/jwks\/client_01EXAMPLE$/);
   });
 
+  it('builds its endpoints from the host it was fetched over, not the configured base URL', async () => {
+    const { app } = createTestApp();
+
+    // The container image is routinely reached as something other than localhost — over
+    // host.docker.internal, a service name, a LAN address — and a document advertising the
+    // configured base URL would point that caller at a host it cannot reach.
+    const res = await app.request(
+      new Request('http://host.docker.internal:4100/user_management/client_01EXAMPLE/.well-known/openid-configuration'),
+    );
+    const body = (await res.json()) as Record<string, string>;
+
+    expect(body.authorization_endpoint).toBe('http://host.docker.internal:4100/user_management/authorize');
+    expect(body.token_endpoint).toBe('http://host.docker.internal:4100/user_management/authenticate');
+    expect(body.jwks_uri).toBe('http://host.docker.internal:4100/sso/jwks/client_01EXAMPLE');
+  });
+
+  it('refuses a client id that could not be one, the way production refuses an unknown one', async () => {
+    const { app } = createTestApp();
+
+    const res = await app.request('/user_management/%3Cscript%3E/.well-known/openid-configuration');
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, string>;
+    expect(body.code).toBe('entity_not_found');
+    // Nothing reflected into a document that then advertises it as a JWKS endpoint.
+    expect(body).not.toHaveProperty('jwks_uri');
+  });
+
   it('advertises the issuer it actually mints, so a client can validate iss against it', async () => {
     const { app, store } = createTestApp();
     const ws = getWorkOSStore(store);

--- a/src/workos/routes/sso.spec.ts
+++ b/src/workos/routes/sso.spec.ts
@@ -606,3 +606,38 @@ describe('SSO authentication events', () => {
     expect(await res.json()).toEqual({ success: true });
   });
 });
+
+describe('OIDC discovery', () => {
+  it('serves the document unauthenticated, shaped as production does', async () => {
+    const { app } = createTestApp();
+
+    const res = await app.request(
+      '/user_management/client_01EXAMPLE/.well-known/openid-configuration',
+      // deliberately no Authorization header
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(
+      ['authorization_endpoint', 'issuer', 'jwks_uri', 'response_types_supported', 'token_endpoint'].sort(),
+    );
+    expect(body.response_types_supported).toEqual(['code']);
+    expect(body.authorization_endpoint).toMatch(/\/user_management\/authorize$/);
+    expect(body.token_endpoint).toMatch(/\/user_management\/authenticate$/);
+    // Per client, like production's.
+    expect(body.jwks_uri).toMatch(/\/sso\/jwks\/client_01EXAMPLE$/);
+  });
+
+  it('advertises the issuer it actually mints, so a client can validate iss against it', async () => {
+    const { app } = createTestApp();
+
+    const doc = (await (
+      await app.request('/user_management/client_01EXAMPLE/.well-known/openid-configuration')
+    ).json()) as Record<string, string>;
+
+    const jwks = await (await app.request('/sso/jwks/client_01EXAMPLE')).json();
+    expect(jwks).toHaveProperty('keys');
+    expect(typeof doc.issuer).toBe('string');
+    expect(doc.issuer.length).toBeGreaterThan(0);
+  });
+});

--- a/src/workos/routes/sso.spec.ts
+++ b/src/workos/routes/sso.spec.ts
@@ -8,8 +8,8 @@ import type { Store } from '../../core/index.js';
 const apiKeys: ApiKeyMap = { sk_test_sso: { environment: 'test' } };
 const headers = { Authorization: 'Bearer sk_test_sso', 'Content-Type': 'application/json' };
 
-function createTestApp() {
-  return createServer(workosPlugin, { port: 0, baseUrl: 'http://localhost:0', apiKeys });
+function createTestApp(options: { baseUrl?: string } = {}) {
+  return createServer(workosPlugin, { port: 0, baseUrl: options.baseUrl ?? 'http://localhost:0', apiKeys });
 }
 
 describe('SSO routes', () => {
@@ -644,16 +644,37 @@ describe('OIDC discovery', () => {
     expect(body.jwks_uri).toBe('http://host.docker.internal:4100/sso/jwks/client_01EXAMPLE');
   });
 
-  it('refuses a client id that could not be one, the way production refuses an unknown one', async () => {
+  it.each([
+    ['punctuation an id never carries', '%3Cscript%3E'],
+    // Alphanumeric, so a character-set check served this one a document advertising
+    // `/sso/jwks/notaclient` as a key endpoint. Nothing without the prefix is a client id.
+    ['a bare word with no client_ prefix', 'notaclient'],
+  ])('refuses %s, the way production refuses an unknown id', async (_case, id) => {
     const { app } = createTestApp();
 
-    const res = await app.request('/user_management/%3Cscript%3E/.well-known/openid-configuration');
+    const res = await app.request(`/user_management/${id}/.well-known/openid-configuration`);
 
     expect(res.status).toBe(404);
     const body = (await res.json()) as Record<string, string>;
     expect(body.code).toBe('entity_not_found');
     // Nothing reflected into a document that then advertises it as a JWKS endpoint.
     expect(body).not.toHaveProperty('jwks_uri');
+  });
+
+  it('reports an issuer equal to the URL the document was fetched from, per OIDC Discovery §4.3', async () => {
+    const { app } = createTestApp({ baseUrl: 'https://api.workos.com' });
+
+    // §4.3: "The `issuer` value returned MUST be identical to the Issuer URL that was used as
+    // the prefix to /.well-known/openid-configuration". That prefix carries the client id, so a
+    // bare issuer can never satisfy it — openid-client v6, Spring's fromIssuerLocation and pyoidc
+    // all throw before they reach `token_endpoint`, which is the one class of client that fetches
+    // this document at all.
+    const res = await app.request(
+      new Request('https://api.workos.com/user_management/client_01EXAMPLE/.well-known/openid-configuration'),
+    );
+    const body = (await res.json()) as Record<string, string>;
+
+    expect(body.issuer).toBe('https://api.workos.com/user_management/client_01EXAMPLE');
   });
 
   it('advertises the issuer it actually mints, so a client can validate iss against it', async () => {

--- a/src/workos/routes/sso.spec.ts
+++ b/src/workos/routes/sso.spec.ts
@@ -629,15 +629,50 @@ describe('OIDC discovery', () => {
   });
 
   it('advertises the issuer it actually mints, so a client can validate iss against it', async () => {
-    const { app } = createTestApp();
+    const { app, store } = createTestApp();
+    const ws = getWorkOSStore(store);
+
+    ws.users.insert({
+      object: 'user',
+      name: null,
+      email: 'discovery@test.com',
+      first_name: null,
+      last_name: null,
+      email_verified: true,
+      profile_picture_url: null,
+      last_sign_in_at: null,
+      external_id: null,
+      metadata: {},
+      locale: null,
+      password_hash: null,
+      impersonator: null,
+    });
 
     const doc = (await (
       await app.request('/user_management/client_01EXAMPLE/.well-known/openid-configuration')
     ).json()) as Record<string, string>;
 
-    const jwks = await (await app.request('/sso/jwks/client_01EXAMPLE')).json();
-    expect(jwks).toHaveProperty('keys');
-    expect(typeof doc.issuer).toBe('string');
-    expect(doc.issuer.length).toBeGreaterThan(0);
+    // Mint a real token through the flow the document advertises, rather than trusting the
+    // document about itself: a client fetches discovery precisely to validate `iss`, so the two
+    // drifting apart is the failure worth catching.
+    const authorize = await app.request(
+      '/user_management/authorize?redirect_uri=http://localhost:3000/callback&client_id=client_01EXAMPLE',
+    );
+    const code = new URL(authorize.headers.get('location')!).searchParams.get('code')!;
+    const token = (await (
+      await app.request('/user_management/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ grant_type: 'authorization_code', code, client_id: 'client_01EXAMPLE' }),
+      })
+    ).json()) as { access_token: string };
+
+    const claims = JSON.parse(Buffer.from(token.access_token.split('.')[1]!, 'base64url').toString()) as Record<
+      string,
+      string
+    >;
+
+    expect(claims.iss).toBe(doc.issuer);
+    expect(claims.aud).toBe('client_01EXAMPLE');
   });
 });

--- a/src/workos/routes/sso.spec.ts
+++ b/src/workos/routes/sso.spec.ts
@@ -608,6 +608,40 @@ describe('SSO authentication events', () => {
 });
 
 describe('OIDC discovery', () => {
+  const seedUser = (store: Store) =>
+    getWorkOSStore(store).users.insert({
+      object: 'user',
+      name: null,
+      email: 'discovery@test.com',
+      first_name: null,
+      last_name: null,
+      email_verified: true,
+      profile_picture_url: null,
+      last_sign_in_at: null,
+      external_id: null,
+      metadata: {},
+      locale: null,
+      password_hash: null,
+      impersonator: null,
+    });
+
+  /** Sign in through the flow the document advertises and return the access token's claims. */
+  const mintToken = async (app: ReturnType<typeof createTestApp>['app'], origin: string, clientId: string) => {
+    const authorize = await app.request(
+      `${origin}/user_management/authorize?redirect_uri=http://localhost:3000/callback&client_id=${clientId}`,
+    );
+    const code = new URL(authorize.headers.get('location')!).searchParams.get('code')!;
+    const token = (await (
+      await app.request(`${origin}/user_management/authenticate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ grant_type: 'authorization_code', code, client_id: clientId }),
+      })
+    ).json()) as { access_token: string };
+
+    return JSON.parse(Buffer.from(token.access_token.split('.')[1]!, 'base64url').toString()) as Record<string, string>;
+  };
+
   it('serves the document unauthenticated, shaped as production does', async () => {
     const { app } = createTestApp();
 
@@ -661,6 +695,38 @@ describe('OIDC discovery', () => {
     expect(body).not.toHaveProperty('jwks_uri');
   });
 
+  it.each([
+    ['a readable pinned id', 'client_local_backend'],
+    ['a hyphenated one', 'client_web-app'],
+  ])('serves %s, since that is an id the emulator mints an `iss` from', async (_case, clientId) => {
+    const { app, store } = createTestApp({ baseUrl: 'https://api.workos.com' });
+    seedUser(store);
+
+    // Walk it the way a discovering client does: mint a token, read `iss`, fetch the document
+    // `iss` promises is there. Production ids are ULIDs, but the emulator lets you pin a readable
+    // one — `client_local_backend` is the README's own — and `authorize`, `authenticate` and
+    // `/sso/jwks` take any id and build `iss` from it. A shape check stricter than theirs 404s a
+    // client at its own issuer, which is the dead end this route exists to remove.
+    const claims = await mintToken(app, 'https://api.workos.com', clientId);
+    expect(claims.iss).toBe(`https://api.workos.com/user_management/${clientId}`);
+
+    const res = await app.request(`${claims.iss}/.well-known/openid-configuration`);
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, string>).issuer).toBe(claims.iss);
+  });
+
+  it('404s a trailing slash rather than 401ing it', async () => {
+    const { app } = createTestApp();
+
+    const res = await app.request('/user_management/client_01EXAMPLE/.well-known/openid-configuration/');
+
+    // The route itself does not match the trailing slash, and need not. What it must not do is
+    // fall to the auth middleware: a 401 says the document is behind a credential and invites a
+    // retry that cannot succeed, which is the confusion this whole route exists to end.
+    expect(res.status).toBe(404);
+  });
+
   it('reports an issuer equal to the URL the document was fetched from, per OIDC Discovery §4.3', async () => {
     const { app } = createTestApp({ baseUrl: 'https://api.workos.com' });
 
@@ -679,23 +745,7 @@ describe('OIDC discovery', () => {
 
   it('advertises the issuer it actually mints, so a client can validate iss against it', async () => {
     const { app, store } = createTestApp();
-    const ws = getWorkOSStore(store);
-
-    ws.users.insert({
-      object: 'user',
-      name: null,
-      email: 'discovery@test.com',
-      first_name: null,
-      last_name: null,
-      email_verified: true,
-      profile_picture_url: null,
-      last_sign_in_at: null,
-      external_id: null,
-      metadata: {},
-      locale: null,
-      password_hash: null,
-      impersonator: null,
-    });
+    seedUser(store);
 
     const doc = (await (
       await app.request('/user_management/client_01EXAMPLE/.well-known/openid-configuration')
@@ -704,22 +754,7 @@ describe('OIDC discovery', () => {
     // Mint a real token through the flow the document advertises, rather than trusting the
     // document about itself: a client fetches discovery precisely to validate `iss`, so the two
     // drifting apart is the failure worth catching.
-    const authorize = await app.request(
-      '/user_management/authorize?redirect_uri=http://localhost:3000/callback&client_id=client_01EXAMPLE',
-    );
-    const code = new URL(authorize.headers.get('location')!).searchParams.get('code')!;
-    const token = (await (
-      await app.request('/user_management/authenticate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ grant_type: 'authorization_code', code, client_id: 'client_01EXAMPLE' }),
-      })
-    ).json()) as { access_token: string };
-
-    const claims = JSON.parse(Buffer.from(token.access_token.split('.')[1]!, 'base64url').toString()) as Record<
-      string,
-      string
-    >;
+    const claims = await mintToken(app, '', 'client_01EXAMPLE');
 
     expect(claims.iss).toBe(doc.issuer);
     expect(claims.aud).toBe('client_01EXAMPLE');

--- a/src/workos/routes/sso.ts
+++ b/src/workos/routes/sso.ts
@@ -323,26 +323,44 @@ export function ssoRoutes(ctx: RouteContext): void {
    * `/user_management/{client_id}/.well-known/openid-configuration`. Unauthenticated, as it is
    * upstream: a client fetches it before it holds anything.
    *
-   * `issuer` is the emulator's configured issuer rather than production's
-   * `{base}/user_management/{client_id}`, because it has to match the `iss` the emulator
-   * actually mints or a client validating one against the other rejects every token. Production
-   * can derive it per client; the emulator has a single issuer and reports that.
+   * Endpoints are built from the requested origin rather than the configured base URL, because a
+   * document is only useful to whoever fetched it. Reached over host.docker.internal or a LAN
+   * address — both ordinary for the container image — a base-URL document would advertise
+   * localhost, which is precisely the host that caller cannot reach.
    *
-   * The client id is not checked, which production does do, returning `entity_not_found`. There
-   * is an application registry — `connectApplications`, which `/oauth2/*` looks a client up in —
-   * but nothing puts an AuthKit client there: no route under `/user_management` or `/sso` ever
-   * consults it, authorize accepts any `client_id`, and `/sso/jwks/:clientId` serves any id.
-   * Gating here alone would 404 for every emulator that has not seeded its AuthKit client as a
-   * connect application, which is the default.
+   * `issuer` is the exception, and stays the configured issuer: it has to match the `iss` the
+   * emulator mints or a client validating one against the other rejects every token. Production
+   * derives it per client as `{base}/user_management/{client_id}`; the emulator has one issuer
+   * and reports that.
+   *
+   * A client id that could not be one is refused the way production refuses an unknown one.
+   * Registered clients cannot be told apart here — no route under `/user_management` or `/sso`
+   * consults the `connectApplications` registry, so an AuthKit client is never in it — but
+   * anything outside the character set an id can use is not a client under any reading, and
+   * serving it would only reflect junk back into `jwks_uri`.
    */
+  const CLIENT_ID_SHAPE = /^[A-Za-z0-9_-]+$/;
+
   app.get('/user_management/:clientId/.well-known/openid-configuration', (c) => {
     const clientId = c.req.param('clientId');
+    if (!CLIENT_ID_SHAPE.test(clientId)) {
+      return c.json(
+        {
+          message: `Application not found: '${clientId}'.`,
+          code: 'entity_not_found',
+          entity_id: clientId,
+        },
+        404,
+      );
+    }
+
+    const origin = new URL(c.req.url).origin;
     return c.json({
       issuer: jwt.issuer,
-      authorization_endpoint: `${ctx.baseUrl}/user_management/authorize`,
-      token_endpoint: `${ctx.baseUrl}/user_management/authenticate`,
+      authorization_endpoint: `${origin}/user_management/authorize`,
+      token_endpoint: `${origin}/user_management/authenticate`,
       response_types_supported: ['code'],
-      jwks_uri: `${ctx.baseUrl}/sso/jwks/${clientId}`,
+      jwks_uri: `${origin}/sso/jwks/${clientId}`,
     });
   });
 

--- a/src/workos/routes/sso.ts
+++ b/src/workos/routes/sso.ts
@@ -347,8 +347,14 @@ export function ssoRoutes(ctx: RouteContext): void {
    * consults the `connectApplications` registry, so an AuthKit client is never in it — so this
    * checks the one thing that needs no registry: that the id is shaped like a client id at all.
    * Serving anything else would reflect it straight back out as a `jwks_uri`.
+   *
+   * Deliberately no narrower than that. Production ids are ULIDs, but the emulator lets you pin
+   * a readable one — `client_local_backend`, the README's own example — and `authorize`,
+   * `authenticate` and
+   * `/sso/jwks` all take any id and mint `iss` from it. A shape stricter than theirs would 404
+   * the discovery document at the very issuer the emulator puts in its own tokens.
    */
-  const CLIENT_ID_SHAPE = /^client_[A-Za-z0-9]+$/;
+  const CLIENT_ID_SHAPE = /^client_[A-Za-z0-9_-]+$/;
 
   app.get('/user_management/:clientId/.well-known/openid-configuration', (c) => {
     const clientId = c.req.param('clientId');

--- a/src/workos/routes/sso.ts
+++ b/src/workos/routes/sso.ts
@@ -323,23 +323,32 @@ export function ssoRoutes(ctx: RouteContext): void {
    * `/user_management/{client_id}/.well-known/openid-configuration`. Unauthenticated, as it is
    * upstream: a client fetches it before it holds anything.
    *
+   * These five fields are the whole document production returns — `openidConfiguration` in
+   * `api/src/userland-sessions/userland-sso.controller.ts`. Notably absent are
+   * `subject_types_supported` and `id_token_signing_alg_values_supported`, which OIDC Discovery
+   * 1.0 §3 marks REQUIRED. Their absence is fidelity, not oversight: adding them here would
+   * make a client that needs them pass against the emulator and fail against WorkOS, which is
+   * the one outcome an emulator must never produce.
+   *
    * Endpoints are built from the requested origin rather than the configured base URL, because a
    * document is only useful to whoever fetched it. Reached over host.docker.internal or a LAN
    * address — both ordinary for the container image — a base-URL document would advertise
-   * localhost, which is precisely the host that caller cannot reach.
+   * localhost, which is precisely the host that caller cannot reach. Production has no such
+   * problem to solve: it builds them from a configured `API_URL`, the only name it answers on.
    *
-   * `issuer` is the exception, and stays the configured issuer: it has to match the `iss` the
-   * emulator mints or a client validating one against the other rejects every token. Production
-   * derives it per client as `{base}/user_management/{client_id}`; the emulator has one issuer
-   * and reports that.
+   * `issuer` is the exception, and comes from `jwt.authKitIssuer` rather than the origin, because
+   * it has to equal the `iss` the emulator mints — a client fetches this document precisely to
+   * validate one against the other.
    *
-   * A client id that could not be one is refused the way production refuses an unknown one.
-   * Registered clients cannot be told apart here — no route under `/user_management` or `/sso`
-   * consults the `connectApplications` registry, so an AuthKit client is never in it — but
-   * anything outside the character set an id can use is not a client under any reading, and
-   * serving it would only reflect junk back into `jwks_uri`.
+   * A client id that could not be one is refused the way production refuses an unknown one,
+   * verified against `api.workos.com`:
+   * `{"message":"Application not found: '…'","code":"entity_not_found","entity_id":"…"}`.
+   * Registered clients still cannot be told apart — no route under `/user_management` or `/sso`
+   * consults the `connectApplications` registry, so an AuthKit client is never in it — so this
+   * checks the one thing that needs no registry: that the id is shaped like a client id at all.
+   * Serving anything else would reflect it straight back out as a `jwks_uri`.
    */
-  const CLIENT_ID_SHAPE = /^[A-Za-z0-9_-]+$/;
+  const CLIENT_ID_SHAPE = /^client_[A-Za-z0-9]+$/;
 
   app.get('/user_management/:clientId/.well-known/openid-configuration', (c) => {
     const clientId = c.req.param('clientId');
@@ -356,7 +365,7 @@ export function ssoRoutes(ctx: RouteContext): void {
 
     const origin = new URL(c.req.url).origin;
     return c.json({
-      issuer: jwt.issuer,
+      issuer: jwt.authKitIssuer(clientId),
       authorization_endpoint: `${origin}/user_management/authorize`,
       token_endpoint: `${origin}/user_management/authenticate`,
       response_types_supported: ['code'],

--- a/src/workos/routes/sso.ts
+++ b/src/workos/routes/sso.ts
@@ -318,6 +318,32 @@ export function ssoRoutes(ctx: RouteContext): void {
   app.get('/sso/jwks', jwks);
   app.get('/sso/jwks/:clientId', jwks);
 
+  /**
+   * OIDC discovery, which production serves per AuthKit client at
+   * `/user_management/{client_id}/.well-known/openid-configuration`. Unauthenticated, as it is
+   * upstream: a client fetches it before it holds anything.
+   *
+   * `issuer` is the emulator's configured issuer rather than production's
+   * `{base}/user_management/{client_id}`, because it has to match the `iss` the emulator
+   * actually mints or a client validating one against the other rejects every token. Production
+   * can derive it per client; the emulator has a single issuer and reports that.
+   *
+   * The client id is not checked, which production does do, returning `entity_not_found`. The
+   * emulator has no registry of AuthKit clients — authorize accepts any `client_id` and
+   * `/sso/jwks/:clientId` serves any id — so refusing here alone would only break callers using
+   * a made-up id everywhere else.
+   */
+  app.get('/user_management/:clientId/.well-known/openid-configuration', (c) => {
+    const clientId = c.req.param('clientId');
+    return c.json({
+      issuer: jwt.issuer,
+      authorization_endpoint: `${ctx.baseUrl}/user_management/authorize`,
+      token_endpoint: `${ctx.baseUrl}/user_management/authenticate`,
+      response_types_supported: ['code'],
+      jwks_uri: `${ctx.baseUrl}/sso/jwks/${clientId}`,
+    });
+  });
+
   // SSO Single Logout — generate logout token
   app.post('/sso/logout/authorize', async (c) => {
     const body = await parseJsonBody(c);

--- a/src/workos/routes/sso.ts
+++ b/src/workos/routes/sso.ts
@@ -328,10 +328,12 @@ export function ssoRoutes(ctx: RouteContext): void {
    * actually mints or a client validating one against the other rejects every token. Production
    * can derive it per client; the emulator has a single issuer and reports that.
    *
-   * The client id is not checked, which production does do, returning `entity_not_found`. The
-   * emulator has no registry of AuthKit clients — authorize accepts any `client_id` and
-   * `/sso/jwks/:clientId` serves any id — so refusing here alone would only break callers using
-   * a made-up id everywhere else.
+   * The client id is not checked, which production does do, returning `entity_not_found`. There
+   * is an application registry — `connectApplications`, which `/oauth2/*` looks a client up in —
+   * but nothing puts an AuthKit client there: no route under `/user_management` or `/sso` ever
+   * consults it, authorize accepts any `client_id`, and `/sso/jwks/:clientId` serves any id.
+   * Gating here alone would 404 for every emulator that has not seeded its AuthKit client as a
+   * connect application, which is the default.
    */
   app.get('/user_management/:clientId/.well-known/openid-configuration', (c) => {
     const clientId = c.req.param('clientId');


### PR DESCRIPTION
Production serves an OIDC discovery document per AuthKit client at `/user_management/{client_id}/.well-known/openid-configuration`, unauthenticated. The emulator had no such route, so it fell to the auth middleware and answered **401**, which reads as "wrong credentials" and invites a retry that cannot succeed, rather than "not here".

Verified against `api.workos.com` while writing this. Same five fields, same shapes:

| Field | Production | This PR |
|---|---|---|
| `authorization_endpoint` | `{base}/user_management/authorize` | same |
| `token_endpoint` | `{base}/user_management/authenticate` | same |
| `response_types_supported` | `["code"]` | same |
| `jwks_uri` | `{base}/sso/jwks/{client_id}` | same |
| `issuer` | `{base}/user_management/{client_id}` | the emulator's configured issuer |

## The two deliberate differences

**`issuer`.** Production derives it per client. The emulator has one configured issuer and reports that, because it is what goes in `iss`, and a client that fetches discovery to validate tokens has to see the two agree. Matching production's shape would mean minting `iss` per client, which changes what `--issuer` means and would break anyone pinning it. Happy to do that instead if you would rather the document matched exactly.

**The client id is not validated.** Production answers `{"message":"Application not found: '…'","code":"entity_not_found","entity_id":"…"}` for an unknown one.

I first wrote that the emulator has no client registry, which is wrong: `connectApplications` is one, and `/oauth2/*` does look a client up in it (`ws.connectApplications.findOneBy('client_id', clientId)`). The accurate statement is narrower. Nothing registers an AuthKit client there: no route under `/user_management` or `/sso` consults that collection at all, `/user_management/authorize` accepts any `client_id` (verified: an unregistered id still redirects with a code), and `/sso/jwks/:clientId` serves any id.

So gating discovery on the registry would 404 for every emulator that has not seeded its AuthKit client as a connect application, which is the default and, I suspect, every current user. If you would rather it matched production exactly, the change is small, but it wants a decision about whether AuthKit clients belong in `connectApplications` at all — at which point `authorize` and `/sso/jwks` arguably ought to gate on it too, and that is a much larger PR than this one.

## Notes

- The path carries an id, so it cannot be matched exactly against `PUBLIC_PATHS`; it is allowed by a narrow regexp beside that list rather than opening the whole `/user_management/` prefix.
- `SUPPORTED.md` regenerates unchanged, since the route is not in the spec-derived matrix.
- Two tests: the document is served without an `Authorization` header and has production's field set and shapes, and its `issuer` is the one the emulator mints.

`bun test` 905 pass, 0 fail. `typecheck`, `oxlint`, `oxfmt --check` clean.

