### PR TITLE
fix(fga): accept role_slug when creating role assignments

### DIFF
--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -335,6 +335,10 @@ export interface WorkOSRoleAssignment extends Entity {
   object: 'role_assignment';
   organization_membership_id: string;
   role_id: string;
+  role_slug: string;
+  resource_id: string | null;
+  resource_external_id: string | null;
+  resource_type_slug: string | null;
 }
 
 export interface WorkOSDirectory extends Entity {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -906,7 +906,23 @@ export function formatAuthorizationResource(r: WorkOSAuthorizationResource): Rec
 }
 
 export function formatRoleAssignment(ra: WorkOSRoleAssignment): Record<string, unknown> {
-  return formatEntity(ra);
+  return {
+    object: 'role_assignment',
+    id: ra.id,
+    organization_membership_id: ra.organization_membership_id,
+    // role_id is not part of the production shape, but is kept for
+    // compatibility with earlier emulator releases.
+    role_id: ra.role_id,
+    role: { slug: ra.role_slug ?? null },
+    resource: {
+      id: ra.resource_id ?? null,
+      external_id: ra.resource_external_id ?? null,
+      resource_type_slug: ra.resource_type_slug ?? null,
+    },
+    source: { type: 'direct', group_role_assignment_id: null },
+    created_at: ra.created_at,
+    updated_at: ra.updated_at,
+  };
 }
 
 export function formatDeviceAuthorization(d: WorkOSDeviceAuthorization, baseUrl: string): Record<string, unknown> {

--- a/src/workos/routes/authorization-checks.spec.ts
+++ b/src/workos/routes/authorization-checks.spec.ts
@@ -134,6 +134,93 @@ describe('Authorization check + role assignment routes', () => {
     expect(body.data[0].organization_membership_id).toBe(membership.id);
   });
 
+  it('creates a role assignment via role_slug (production/SDK contract)', async () => {
+    const { membership, adminRole } = await setup();
+
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role' }),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.object).toBe('role_assignment');
+    expect(body.organization_membership_id).toBe(membership.id);
+    expect(body.role_id).toBe(adminRole.id);
+    expect(body.role).toEqual({ slug: 'admin-role' });
+    expect(body.resource).toEqual({ id: null, external_id: null, resource_type_slug: null });
+    expect(body.source).toEqual({ type: 'direct', group_role_assignment_id: null });
+
+    // The assignment grants its permissions
+    const checkRes = await req(`/authorization/organization_memberships/${membership.id}/check`, {
+      method: 'POST',
+      body: JSON.stringify({ permission: 'admin:manage' }),
+    });
+    expect((await json(checkRes)).authorized).toBe(true);
+  });
+
+  it('creates a role assignment scoped to a resource by external id', async () => {
+    const { membership, org } = await setup();
+
+    const resourceRes = await req('/authorization/resources', {
+      method: 'POST',
+      body: JSON.stringify({ resource_type_slug: 'doc', external_id: 'doc-1', organization_id: org.id }),
+    });
+    const resource = await json(resourceRes);
+
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_external_id: 'doc-1', resource_type_slug: 'doc' }),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.resource).toEqual({ id: resource.id, external_id: 'doc-1', resource_type_slug: 'doc' });
+  });
+
+  it('creates a role assignment scoped to a resource by id', async () => {
+    const { membership, org } = await setup();
+
+    const resourceRes = await req('/authorization/resources', {
+      method: 'POST',
+      body: JSON.stringify({ resource_type_slug: 'doc', external_id: 'doc-2', organization_id: org.id }),
+    });
+    const resource = await json(resourceRes);
+
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_id: resource.id }),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.resource.id).toBe(resource.id);
+  });
+
+  it('returns 404 for an unknown role_slug', async () => {
+    const { membership } = await setup();
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'no-such-role' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for an unknown resource target', async () => {
+    const { membership } = await setup();
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_id: 'resource_nonexistent' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('requires role_slug or role_id when creating a role assignment', async () => {
+    const { membership } = await setup();
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(422);
+  });
+
   it('deletes a role assignment', async () => {
     const { membership, adminRole } = await setup();
 

--- a/src/workos/routes/authorization-checks.spec.ts
+++ b/src/workos/routes/authorization-checks.spec.ts
@@ -194,6 +194,45 @@ describe('Authorization check + role assignment routes', () => {
     expect(body.resource.id).toBe(resource.id);
   });
 
+  it('prefers the organization role when its slug collides with an environment role', async () => {
+    const { membership, org } = await setup();
+
+    // 'admin-role' already exists as an environment role (created first in setup)
+    const orgRoleRes = await req(`/authorization/organizations/${org.id}/roles`, {
+      method: 'POST',
+      body: JSON.stringify({ slug: 'admin-role', name: 'Org Admin' }),
+    });
+    const orgRole = await json(orgRoleRes);
+
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role' }),
+    });
+    expect(res.status).toBe(201);
+    expect((await json(res)).role_id).toBe(orgRole.id);
+  });
+
+  it('returns 404 when resource_id belongs to another organization', async () => {
+    const { membership } = await setup();
+
+    const otherOrgRes = await req('/organizations', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Other Org' }),
+    });
+    const otherOrg = await json(otherOrgRes);
+    const resourceRes = await req('/authorization/resources', {
+      method: 'POST',
+      body: JSON.stringify({ resource_type_slug: 'doc', external_id: 'doc-other', organization_id: otherOrg.id }),
+    });
+    const resource = await json(resourceRes);
+
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_id: resource.id }),
+    });
+    expect(res.status).toBe(404);
+  });
+
   it('returns 404 for an unknown role_slug', async () => {
     const { membership } = await setup();
     const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {

--- a/src/workos/routes/authorization-checks.spec.ts
+++ b/src/workos/routes/authorization-checks.spec.ts
@@ -251,6 +251,39 @@ describe('Authorization check + role assignment routes', () => {
     expect(res.status).toBe(404);
   });
 
+  it('returns 404 when resource_external_id matches but resource_type_slug does not', async () => {
+    const { membership, org } = await setup();
+
+    await req('/authorization/resources', {
+      method: 'POST',
+      body: JSON.stringify({ resource_type_slug: 'doc', external_id: 'doc-3', organization_id: org.id }),
+    });
+
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_external_id: 'doc-3', resource_type_slug: 'folder' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('requires resource_type_slug when resource_external_id is provided', async () => {
+    const { membership } = await setup();
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_external_id: 'doc-1' }),
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it('requires resource_external_id when resource_type_slug is provided', async () => {
+    const { membership } = await setup();
+    const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {
+      method: 'POST',
+      body: JSON.stringify({ role_slug: 'admin-role', resource_type_slug: 'doc' }),
+    });
+    expect(res.status).toBe(422);
+  });
+
   it('requires role_slug or role_id when creating a role assignment', async () => {
     const { membership } = await setup();
     const res = await req(`/authorization/organization_memberships/${membership.id}/role_assignments`, {

--- a/src/workos/routes/authorization-checks.ts
+++ b/src/workos/routes/authorization-checks.ts
@@ -1,4 +1,5 @@
 import { type RouteContext, notFound, validationError, parseJsonBody, parseListParams } from '../../core/index.js';
+import type { WorkOSAuthorizationResource } from '../entities.js';
 import { getWorkOSStore } from '../store.js';
 import { formatRoleAssignment, formatAuthorizationResource, formatListResponse } from '../helpers.js';
 
@@ -101,18 +102,51 @@ export function authorizationCheckRoutes(ctx: RouteContext): void {
     if (!membership) throw notFound('OrganizationMembership');
 
     const body = await parseJsonBody(c);
-    const roleId = body.role_id as string;
-    if (!roleId) {
-      throw validationError('role_id is required', [{ field: 'role_id', code: 'required' }]);
+    const roleSlug = body.role_slug as string | undefined;
+    // role_id is not part of the production contract, but is accepted for
+    // compatibility with earlier emulator releases.
+    const roleId = body.role_id as string | undefined;
+    if (!roleSlug && !roleId) {
+      throw validationError('role_slug is required', [{ field: 'role_slug', code: 'required' }]);
     }
 
-    const role = ws.roles.get(roleId);
+    const role = roleSlug
+      ? ws.roles
+          .findBy('slug', roleSlug)
+          .find((r) => r.organization_id === membership.organization_id || r.type === 'EnvironmentRole')
+      : ws.roles.get(roleId as string);
     if (!role) throw notFound('Role');
+
+    const resourceId = body.resource_id as string | undefined;
+    const resourceExternalId = body.resource_external_id as string | undefined;
+    const resourceTypeSlug = body.resource_type_slug as string | undefined;
+
+    let resource: WorkOSAuthorizationResource | null = null;
+    if (resourceId) {
+      resource = ws.authorizationResources.get(resourceId) ?? null;
+      if (!resource) throw notFound('Resource');
+    } else if (resourceExternalId) {
+      if (!resourceTypeSlug) {
+        throw validationError('resource_type_slug is required when resource_external_id is provided', [
+          { field: 'resource_type_slug', code: 'required' },
+        ]);
+      }
+      resource =
+        ws.authorizationResources
+          .findBy('external_id', resourceExternalId)
+          .find((r) => r.resource_type_slug === resourceTypeSlug && r.organization_id === membership.organization_id) ??
+        null;
+      if (!resource) throw notFound('Resource');
+    }
 
     const assignment = ws.roleAssignments.insert({
       object: 'role_assignment',
       organization_membership_id: membershipId,
-      role_id: roleId,
+      role_id: role.id,
+      role_slug: role.slug,
+      resource_id: resource?.id ?? null,
+      resource_external_id: resource?.external_id ?? null,
+      resource_type_slug: resource?.resource_type_slug ?? null,
     });
 
     return c.json(formatRoleAssignment(assignment), 201);

--- a/src/workos/routes/authorization-checks.ts
+++ b/src/workos/routes/authorization-checks.ts
@@ -136,6 +136,10 @@ export function authorizationCheckRoutes(ctx: RouteContext): void {
           .find((r) => r.resource_type_slug === resourceTypeSlug && r.organization_id === membership.organization_id) ??
         null;
       if (!resource) throw notFound('Resource');
+    } else if (resourceTypeSlug) {
+      throw validationError('resource_external_id is required when resource_type_slug is provided', [
+        { field: 'resource_external_id', code: 'required' },
+      ]);
     }
 
     const assignment = ws.roleAssignments.insert({

--- a/src/workos/routes/authorization-checks.ts
+++ b/src/workos/routes/authorization-checks.ts
@@ -2,6 +2,7 @@ import { type RouteContext, notFound, validationError, parseJsonBody, parseListP
 import type { WorkOSAuthorizationResource } from '../entities.js';
 import { getWorkOSStore } from '../store.js';
 import { formatRoleAssignment, formatAuthorizationResource, formatListResponse } from '../helpers.js';
+import { findEnvRole, findOrgRole } from '../role-helpers.js';
 
 /**
  * Gather all permission slugs for a given membership:
@@ -111,9 +112,7 @@ export function authorizationCheckRoutes(ctx: RouteContext): void {
     }
 
     const role = roleSlug
-      ? ws.roles
-          .findBy('slug', roleSlug)
-          .find((r) => r.organization_id === membership.organization_id || r.type === 'EnvironmentRole')
+      ? (findOrgRole(ws, membership.organization_id, roleSlug) ?? findEnvRole(ws, roleSlug))
       : ws.roles.get(roleId as string);
     if (!role) throw notFound('Role');
 
@@ -124,7 +123,7 @@ export function authorizationCheckRoutes(ctx: RouteContext): void {
     let resource: WorkOSAuthorizationResource | null = null;
     if (resourceId) {
       resource = ws.authorizationResources.get(resourceId) ?? null;
-      if (!resource) throw notFound('Resource');
+      if (!resource || resource.organization_id !== membership.organization_id) throw notFound('Resource');
     } else if (resourceExternalId) {
       if (!resourceTypeSlug) {
         throw validationError('resource_type_slug is required when resource_external_id is provided', [


### PR DESCRIPTION
## Summary
Fixes #82.

The create-role-assignment endpoint (`POST /authorization/organization_memberships/:id/role_assignments`) required `role_id`, but production and `@workos-inc/node`'s `assignRole()` send `role_slug` — so SDK calls failed with a `role_id is required` validation error.

## Changes
- Accept `role_slug` (primary, matching the production contract): resolved against org-scoped roles for the membership's org first, then environment roles. `role_id` is still accepted for backward compatibility; a request with neither gets a 422 on `role_slug`.
- Support the SDK's optional resource targets: `resource_id`, or `resource_external_id` + `resource_type_slug` (resolved within the membership's org). Unknown targets 404.
- Align the response with the production shape that `deserializeRoleAssignment` in the Node SDK reads unconditionally: `role: {slug}`, `resource: {id, external_id, resource_type_slug}` (nulls when unscoped), `source: {type: 'direct', group_role_assignment_id: null}`. Without this, `assignRole()` would have thrown a TypeError during deserialization even after the request-field fix. The legacy `role_id` field is kept in the response for compatibility with earlier emulator releases.

## Testing
- New specs: create via `role_slug`, via legacy `role_id`, resource scoping by external id and by id, unknown slug/resource → 404, neither field → 422, response shape assertions.
- Full suite: 909 pass, 0 fail. `bun run typecheck`, `lint`, `fmt:check` clean. `gen:supported` produces no matrix change (endpoint already existed).