### PR TITLE
fix(invitations): emit required nullable keys

### DIFF
--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -215,6 +215,11 @@ export interface WorkOSInvitation extends Entity {
   inviter_user_id: string | null;
   role_slug: string | null;
   expires_at: string;
+  // The generated SDK treats these as nullable-but-required keys: a missing key raises KeyError
+  // on parse. Production always sends them (null when unset), so emulate does too.
+  accepted_at: string | null;
+  revoked_at: string | null;
+  accepted_user_id: string | null;
 }
 
 export interface WorkOSRedirectUri extends Entity {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -547,7 +547,11 @@ export function acceptInvitation(
   ws: WorkOSStore,
   eventBus: EventBus | undefined,
 ): string | null {
-  ws.invitations.update(inv.id, { state: 'accepted' });
+  ws.invitations.update(inv.id, {
+    state: 'accepted',
+    accepted_at: new Date().toISOString(),
+    accepted_user_id: user?.id ?? null,
+  });
   eventBus?.emit({ event: EVENTS.invitationAccepted, data: formatInvitation(ws.invitations.get(inv.id)!) });
 
   if (!inv.organization_id) return null;

--- a/src/workos/index.ts
+++ b/src/workos/index.ts
@@ -610,6 +610,9 @@ export function seedFromConfig(store: Store, _baseUrl: string, config: WorkOSSee
         inviter_user_id: invConfig.inviter_user_id ?? null,
         role_slug: invConfig.role_slug ?? null,
         expires_at: expiresIn(72 * 60),
+        accepted_at: null,
+        revoked_at: null,
+        accepted_user_id: null,
       });
     }
   }

--- a/src/workos/routes/invitations.spec.ts
+++ b/src/workos/routes/invitations.spec.ts
@@ -32,6 +32,10 @@ describe('Invitation routes', () => {
     expect(inv.token).toBeDefined();
     expect(inv.accept_invitation_url).toContain(inv.token);
     expect(inv.id).toMatch(/^inv_/);
+    // The generated SDK reads these as required keys; omitting them raises KeyError on parse.
+    expect(inv.accepted_at).toBeNull();
+    expect(inv.revoked_at).toBeNull();
+    expect(inv.accepted_user_id).toBeNull();
   });
 
   it('lists invitations with email filter', async () => {
@@ -47,6 +51,10 @@ describe('Invitation routes', () => {
     const list = await json(await req('/user_management/invitations?email=a@test.com'));
     expect(list.data).toHaveLength(1);
     expect(list.data[0].email).toBe('a@test.com');
+    // List responses serialize through the same formatter; the required nullable keys appear here too.
+    expect(list.data[0].accepted_at).toBeNull();
+    expect(list.data[0].revoked_at).toBeNull();
+    expect(list.data[0].accepted_user_id).toBeNull();
   });
 
   it('lists invitations with organization_id filter', async () => {
@@ -102,6 +110,10 @@ describe('Invitation routes', () => {
     expect(res.status).toBe(200);
     const accepted = await json(res);
     expect(accepted.state).toBe('accepted');
+    expect(accepted.accepted_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(accepted.revoked_at).toBeNull();
+    // No user signed up under this email, so nobody is recorded as the accepter.
+    expect(accepted.accepted_user_id).toBeNull();
   });
 
   it('accepts invitation with org creates membership', async () => {
@@ -130,6 +142,10 @@ describe('Invitation routes', () => {
     const memberships = await json(await req(`/user_management/organization_memberships?organization_id=${org.id}`));
     expect(memberships.data).toHaveLength(1);
     expect(memberships.data[0].organization_id).toBe(org.id);
+
+    // The recipient exists, so their id is recorded as the accepter.
+    const accepted = await json(await req(`/user_management/invitations/${inv.id}`));
+    expect(accepted.accepted_user_id).toBe(memberships.data[0].user_id);
   });
 
   // Resolving the recipient exactly enrolled nobody for an account stored under a different case:
@@ -230,7 +246,10 @@ describe('Invitation routes', () => {
 
     const res = await req(`/user_management/invitations/${created.id}/revoke`, { method: 'POST' });
     expect(res.status).toBe(200);
-    expect((await json(res)).state).toBe('revoked');
+    const revoked = await json(res);
+    expect(revoked.state).toBe('revoked');
+    expect(revoked.revoked_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(revoked.accepted_at).toBeNull();
   });
 
   it('rejects accept on non-pending invitation', async () => {

--- a/src/workos/routes/invitations.spec.ts
+++ b/src/workos/routes/invitations.spec.ts
@@ -283,6 +283,48 @@ describe('Invitation routes', () => {
     expect(resent.accept_invitation_url).toContain(resent.token);
   });
 
+  // Resending puts the invitation back to pending, so the terminal metadata has to clear with it:
+  // a pending invitation that still carries accepted_at or revoked_at contradicts its own state.
+  it('clears acceptance metadata when an accepted invitation is resent', async () => {
+    const user = await json(
+      await req('/user_management/users', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'resend-accepted@test.com' }),
+      }),
+    );
+    const created = await json(
+      await req('/user_management/invitations', {
+        method: 'POST',
+        body: JSON.stringify({ email: user.email }),
+      }),
+    );
+
+    const accepted = await json(await req(`/user_management/invitations/${created.id}/accept`, { method: 'POST' }));
+    expect(accepted.accepted_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(accepted.accepted_user_id).toBe(user.id);
+
+    const resent = await json(await req(`/user_management/invitations/${created.id}/resend`, { method: 'POST' }));
+    expect(resent.state).toBe('pending');
+    expect(resent.accepted_at).toBeNull();
+    expect(resent.accepted_user_id).toBeNull();
+  });
+
+  it('clears revocation metadata when a revoked invitation is resent', async () => {
+    const created = await json(
+      await req('/user_management/invitations', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'resend-revoked@test.com' }),
+      }),
+    );
+
+    const revoked = await json(await req(`/user_management/invitations/${created.id}/revoke`, { method: 'POST' }));
+    expect(revoked.revoked_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const resent = await json(await req(`/user_management/invitations/${created.id}/resend`, { method: 'POST' }));
+    expect(resent.state).toBe('pending');
+    expect(resent.revoked_at).toBeNull();
+  });
+
   it('deletes an invitation', async () => {
     const created = await json(
       await req('/user_management/invitations', {

--- a/src/workos/routes/invitations.ts
+++ b/src/workos/routes/invitations.ts
@@ -38,6 +38,9 @@ export function invitationRoutes(ctx: RouteContext): void {
       inviter_user_id: (body.inviter_user_id as string) ?? null,
       role_slug: (body.role_slug as string) ?? null,
       expires_at: expiresIn(72 * 60), // 72 hours
+      accepted_at: null,
+      revoked_at: null,
+      accepted_user_id: null,
     });
 
     return c.json(formatInvitation(inv), 201);
@@ -100,7 +103,7 @@ export function invitationRoutes(ctx: RouteContext): void {
       throw new WorkOSApiError(400, `Invitation is ${inv.state}`, 'invalid_invitation_state');
     }
 
-    ws.invitations.update(inv.id, { state: 'revoked' });
+    ws.invitations.update(inv.id, { state: 'revoked', revoked_at: new Date().toISOString() });
     const eventBus = store.getData<EventBus>(STORE_KEYS.eventBus);
     eventBus?.emit({ event: EVENTS.invitationRevoked, data: formatInvitation(ws.invitations.get(inv.id)!) });
     const updated = ws.invitations.get(inv.id)!;

--- a/src/workos/routes/invitations.ts
+++ b/src/workos/routes/invitations.ts
@@ -115,11 +115,17 @@ export function invitationRoutes(ctx: RouteContext): void {
     if (!inv) throw notFound('Invitation');
 
     const newToken = generateVerificationToken();
+    // Resending returns the invitation to pending, so the metadata recording how it left that
+    // state has to go with it — otherwise the response and invitation.resent both carry a
+    // pending invitation that also claims to have been accepted or revoked.
     ws.invitations.update(inv.id, {
       token: newToken,
       accept_invitation_url: `${ctx.baseUrl}/user_management/invitations/accept?token=${newToken}`,
       expires_at: expiresIn(72 * 60),
       state: 'pending',
+      accepted_at: null,
+      accepted_user_id: null,
+      revoked_at: null,
     });
 
     const eventBus = store.getData<EventBus>(STORE_KEYS.eventBus);


### PR DESCRIPTION
fix(invitations): emit required nullable keys

## Summary

- Every invitation object emulate returned was missing `accepted_at`, `revoked_at`, and `accepted_user_id`. The generated Python SDK (v6.0.0+) parses those as required dict keys — a missing key raises `KeyError`, surfaced as `WorkOSError` on any invitation deserialization (`send_invitation`, `get_invitation`, `list_invitations`, accept, resend, revoke).
- Added the three fields to `WorkOSInvitation` and set them to `null` on insert (POST route and seed path), so list/get/send/resend responses now match production, which always sends them (null when unset) — and mirror emulate's own treatment of the other nullable invitation fields (`organization_id`, `inviter_user_id`, `role_slug`).
- Stamps real values on state transitions: `accepted_at` + `accepted_user_id` on accept (via the shared `acceptInvitation` helper, so the REST route and the authenticate `invitation_token` grant stay consistent), and `revoked_at` on revoke.
- Extended the invitation route tests to assert the keys are present and populated across create, list, accept (with and without an existing recipient), and revoke.

Fixes #86
