### PR TITLE
feat(auth): add opt-in password step to interactive login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ dist
 coverage
 .DS_Store
 *.bun-build
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Point your SDK's base URL at the emulator and follow the AuthKit quickstart exac
 
 1. **Create a user** — `POST /user_management/users` → a `user.created` webhook arrives.
 2. **Redirect to AuthKit** — send the browser to `GET /user_management/authorize?redirect_uri=...&state=...`. By default the emulator immediately redirects back to your callback with a `code`; with `--interactive` it serves a real login page first.
-3. **Exchange the code** — your callback calls `POST /user_management/authenticate` with `grant_type=authorization_code`. You get back the user, `access_token`, and `refresh_token` — and `session.created` plus `authentication.oauth_succeeded` webhooks arrive (`authentication.password_succeeded` instead, when the [interactive password page](#requiring-a-password) checked the login).
+3. **Exchange the code** — your callback calls `POST /user_management/authenticate` with `grant_type=authorization_code`. You get back the user, `access_token`, and `refresh_token` — and `session.created` plus `authentication.oauth_succeeded` webhooks arrive (`authentication.password_succeeded` instead, when the [interactive password page](#requiring-a-password) checked the login, or the event of the gate that page cleared last).
 4. **Other methods work the same way** — password, Magic Auth, email verification, MFA, and SSO logins all emit their spec-named `authentication.*_succeeded` events; failed attempts emit `authentication.*_failed` with an `error: { code, message }` object.
 
 Codes that WorkOS would deliver by email are delivered to you in the webhook payload instead: `magic_auth.created` carries the Magic Auth `code`, `password_reset.created` carries the reset `token`, and `email_verification.created` carries the verification `code`. Your test can drive the whole flow from webhooks alone — see `src/e2e.spec.ts` for a complete worked example.
@@ -1213,8 +1213,9 @@ When interactive mode is on:
 2. The emulator serves a login page instead of auto-redirecting
 3. The browser (or agent) fills in the email field and submits the form
 4. With the [password option](#requiring-a-password) on, a user who has a password is asked for it next
-5. If the user belongs to more than one organization, the emulator asks which one, as hosted AuthKit does
-6. The emulator creates an auth code and redirects back to your app's callback URL
+5. Under the same option, the gates the `password` grant enforces follow: an unverified mailbox is asked for its emailed code, then an enrolled second factor for its one-time code
+6. If the user belongs to more than one organization, the emulator asks which one, as hosted AuthKit does
+7. The emulator creates an auth code and redirects back to your app's callback URL
 
 The `login_hint` parameter pre-fills the email field, so agent browsers can skip typing if desired.
 
@@ -1252,15 +1253,17 @@ workos-emulate --interactive-password --seed workos-emulate.config.yaml
 ```ts
 const emulator = await createEmulator({
   interactiveAuth: { password: true },
-  seed: { users: [{ email: 'alice@example.com', password: 'correct-horse' }] },
+  seed: { users: [{ email: 'alice@example.com', password: 'correct-horse', email_verified: true }] },
 });
 ```
 
 - The page shows the email read-only above an `input[name="password"]`, with a "Use a different account" link back to the email page. A user without a password skips it, so a sign-up or a passwordless seed behaves exactly as before.
 - A wrong password re-renders the page with an inline error (HTTP 401) and emits `authentication.password_failed` with `invalid_credentials`, the same event the `password` grant emits. Nothing reaches your callback until the password is right.
 - Once it is, the code the callback receives remembers how it was earned: the exchange emits `authentication.password_succeeded` rather than `authentication.oauth_succeeded`, and the response carries `"authentication_method": "Password"`.
-- The organization page, when there is one, follows the password page and carries a short-lived token rather than the password. Posting an `organization_id` without that token lands back on the password page.
-- MFA challenges and the email-verification gate are not part of the page. Plain `--interactive` is unchanged.
+- The gates the `password` grant enforces apply here too, in the order hosted AuthKit shows them. A user whose `email_verified` is `false` gets a "Verify your email" page for the code that arrives on the `email_verification.created` webhook, and a user with an enrolled factor (`totp: true` in a seed) gets a one-time-code page for a fresh authentication challenge, whose code a test reads from the store as it does to finish the `mfa-totp` grant. Both pages take an `input[name="code"]`. A wrong code re-renders with an inline error (HTTP 401) and emits `authentication.email_verification_failed` or `authentication.mfa_failed`, as the matching grant would.
+- When a gate was cleared, the exchange reports what that grant reports: `authentication.email_verification_succeeded` or `authentication.mfa_succeeded` in place of `authentication.password_succeeded`, with the session and `authentication_method` still recording `Password`. Fixtures that should go from the password straight to the callback want `email_verified: true`, as they do for the `password` grant.
+- Every page after the password carries a short-lived token rather than the password. Posting an `organization_id`, or a code, without that token lands back on the password page, and posting past an open gate lands back on the gate.
+- Plain `--interactive` is unchanged.
 
 ```ts
 test('password login', async ({ page }) => {

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ workos-emulate
 workos-emulate --port 9100 --json
 workos-emulate --seed workos-emulate.config.yaml
 workos-emulate --interactive          # serve login pages for E2E browser testing
+workos-emulate --interactive-password # ...and ask a user who has a password for it
 workos-emulate --signing-key ci-key.pem --issuer https://api.workos.com  # stable JWKS and iss
 workos-emulate --redirect-hosts app.example.test  # allow a non-localhost redirect_uri
 workos-emulate --version
@@ -545,7 +546,7 @@ Point your SDK's base URL at the emulator and follow the AuthKit quickstart exac
 
 1. **Create a user** — `POST /user_management/users` → a `user.created` webhook arrives.
 2. **Redirect to AuthKit** — send the browser to `GET /user_management/authorize?redirect_uri=...&state=...`. By default the emulator immediately redirects back to your callback with a `code`; with `--interactive` it serves a real login page first.
-3. **Exchange the code** — your callback calls `POST /user_management/authenticate` with `grant_type=authorization_code`. You get back the user, `access_token`, and `refresh_token` — and `session.created` plus `authentication.oauth_succeeded` webhooks arrive.
+3. **Exchange the code** — your callback calls `POST /user_management/authenticate` with `grant_type=authorization_code`. You get back the user, `access_token`, and `refresh_token` — and `session.created` plus `authentication.oauth_succeeded` webhooks arrive (`authentication.password_succeeded` instead, when the [interactive password page](#requiring-a-password) checked the login).
 4. **Other methods work the same way** — password, Magic Auth, email verification, MFA, and SSO logins all emit their spec-named `authentication.*_succeeded` events; failed attempts emit `authentication.*_failed` with an `error: { code, message }` object.
 
 Codes that WorkOS would deliver by email are delivered to you in the webhook payload instead: `magic_auth.created` carries the Magic Auth `code`, `password_reset.created` carries the reset `token`, and `email_verification.created` carries the verification `code`. Your test can drive the whole flow from webhooks alone — see `src/e2e.spec.ts` for a complete worked example.
@@ -1211,8 +1212,9 @@ When interactive mode is on:
 1. Your app redirects to `/sso/authorize?connection=...&redirect_uri=...` (or `/user_management/authorize?...`)
 2. The emulator serves a login page instead of auto-redirecting
 3. The browser (or agent) fills in the email field and submits the form
-4. If the user belongs to more than one organization, the emulator asks which one, as hosted AuthKit does
-5. The emulator creates an auth code and redirects back to your app's callback URL
+4. With the [password option](#requiring-a-password) on, a user who has a password is asked for it next
+5. If the user belongs to more than one organization, the emulator asks which one, as hosted AuthKit does
+6. The emulator creates an auth code and redirects back to your app's callback URL
 
 The `login_hint` parameter pre-fills the email field, so agent browsers can skip typing if desired.
 
@@ -1234,6 +1236,40 @@ test('multi-organization login', async ({ page }) => {
 
   // Only shown when the user belongs to several organizations
   await page.click('text=Acme');
+
+  await expect(page).toHaveURL(/dashboard/);
+});
+```
+
+### Requiring a password
+
+The login page asks for an email and nothing else, so a suite signs in as anyone with one form fill. Pass `--interactive-password` (CLI) or `interactiveAuth: { password: true }` (programmatic) to add the step hosted AuthKit puts next: a user who has a password is asked for it after the email and before any organization question.
+
+```bash
+workos-emulate --interactive-password --seed workos-emulate.config.yaml
+```
+
+```ts
+const emulator = await createEmulator({
+  interactiveAuth: { password: true },
+  seed: { users: [{ email: 'alice@example.com', password: 'correct-horse' }] },
+});
+```
+
+- The page shows the email read-only above an `input[name="password"]`, with a "Use a different account" link back to the email page. A user without a password skips it, so a sign-up or a passwordless seed behaves exactly as before.
+- A wrong password re-renders the page with an inline error (HTTP 401) and emits `authentication.password_failed` with `invalid_credentials`, the same event the `password` grant emits. Nothing reaches your callback until the password is right.
+- Once it is, the code the callback receives remembers how it was earned: the exchange emits `authentication.password_succeeded` rather than `authentication.oauth_succeeded`, and the response carries `"authentication_method": "Password"`.
+- The organization page, when there is one, follows the password page and carries a short-lived token rather than the password. Posting an `organization_id` without that token lands back on the password page.
+- MFA challenges and the email-verification gate are not part of the page. Plain `--interactive` is unchanged.
+
+```ts
+test('password login', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+  await page.fill('input[name="email"]', 'alice@example.com');
+  await page.click('button[type="submit"]');
+
+  await page.fill('input[name="password"]', 'correct-horse');
+  await page.click('button[type="submit"]');
 
   await expect(page).toHaveURL(/dashboard/);
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ interface CliArgs {
   help: boolean;
   version: boolean;
   interactive: boolean;
+  interactivePassword: boolean;
   validateConfig: boolean;
 }
 
@@ -57,6 +58,9 @@ Options:
                       hostnames. Accepts subdomain wildcards ("*.example.test") and "*" to
                       allow any host. Repeatable.
   --interactive, -i   Show login pages for SSO/AuthKit (for E2E browser testing)
+  --interactive-password
+                      Also ask a user who has a password for it on the AuthKit login page, as
+                      hosted AuthKit does (implies --interactive)
   --validate-config   Validate seed config file without starting server
   --json              Print startup details as JSON
   --version, -v       Print the installed version
@@ -79,6 +83,7 @@ function parseArgs(argv: string[]): CliArgs {
     help: false,
     version: false,
     interactive: false,
+    interactivePassword: false,
     validateConfig: false,
   };
 
@@ -104,6 +109,12 @@ function parseArgs(argv: string[]): CliArgs {
 
     if (arg === '--interactive' || arg === '-i') {
       parsed.interactive = true;
+      continue;
+    }
+
+    if (arg === '--interactive-password') {
+      parsed.interactive = true;
+      parsed.interactivePassword = true;
       continue;
     }
 
@@ -281,7 +292,7 @@ async function main(): Promise<void> {
     issuer,
     signingKey: signingKeyPath || kid ? { privateKey: readSigningKey(signingKeyPath), kid } : undefined,
     allowedRedirectHosts,
-    interactiveAuth: argv.interactive,
+    interactiveAuth: argv.interactivePassword ? { password: true } : argv.interactive,
   });
 
   if (argv.json) {

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -201,13 +201,17 @@ export class Store {
     return this._data.delete(key);
   }
 
-  deleteDataByPrefix(prefix: string): number {
+  /**
+   * Remove every entry under a prefix, or only those `shouldDelete` selects. Deleting during
+   * iteration is safe on a Map: a removed entry is simply not visited.
+   */
+  deleteDataByPrefix(prefix: string, shouldDelete?: (value: unknown, key: string) => boolean): number {
     let count = 0;
-    for (const key of this._data.keys()) {
-      if (key.startsWith(prefix)) {
-        this._data.delete(key);
-        count++;
-      }
+    for (const [key, value] of this._data) {
+      if (!key.startsWith(prefix)) continue;
+      if (shouldDelete && !shouldDelete(value, key)) continue;
+      this._data.delete(key);
+      count++;
     }
     return count;
   }

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -196,6 +196,11 @@ export class Store {
     this._data.set(key, value);
   }
 
+  /** Remove one data entry outright. `setData(key, undefined)` keeps the key allocated. */
+  deleteData(key: string): boolean {
+    return this._data.delete(key);
+  }
+
   deleteDataByPrefix(prefix: string): number {
     let count = 0;
     for (const key of this._data.keys()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,12 @@ export interface EmulatorOptions {
    * (`['*.example.test']`). `['*']` allows any host, which turns the check off entirely.
    */
   allowedRedirectHosts?: string[];
-  interactiveAuth?: boolean;
+  /**
+   * Serve login pages from the authorize endpoints instead of redirecting straight back with a
+   * code, for browser-driven tests. `true` serves the email-only page; `{ password: true }` also
+   * asks a user who has a password for it, as hosted AuthKit does. See `InteractiveAuthOptions`.
+   */
+  interactiveAuth?: boolean | InteractiveAuthOptions;
   webhookRetryConfig?: {
     maxRetries?: number;
     initialDelayMs?: number;
@@ -85,6 +90,15 @@ export interface EmulatorOptions {
     backoffMultiplier?: number;
   };
   webhookDebugMode?: boolean;
+}
+
+export interface InteractiveAuthOptions {
+  /**
+   * Ask a user who has a password for it after the email step, on its own page, before any
+   * organization selection. A user without a password is not asked. Off by default, because the
+   * one-step email page is what existing browser suites were written against.
+   */
+  password?: boolean;
 }
 
 export interface Emulator {
@@ -135,7 +149,12 @@ export async function createEmulator(options: EmulatorOptions = {}): Promise<Emu
   // from reset() as well. Kept in one place because the failure is silent otherwise: an option
   // set here and not restored there simply stops taking effect after the first reset.
   const applyOptionData = () => {
-    if (options.interactiveAuth) store.setData(STORE_KEYS.interactiveAuth, true);
+    if (options.interactiveAuth) {
+      store.setData(STORE_KEYS.interactiveAuth, true);
+      if (typeof options.interactiveAuth === 'object' && options.interactiveAuth.password) {
+        store.setData(STORE_KEYS.interactivePassword, true);
+      }
+    }
     if (allowedRedirectHosts.length > 0) store.setData(STORE_KEYS.allowedRedirectHosts, allowedRedirectHosts);
     if (options.webhookRetryConfig) store.setData('webhookRetryConfig', options.webhookRetryConfig);
     if (options.webhookDebugMode) store.setData('webhookDebugMode', true);

--- a/src/workos/constants.ts
+++ b/src/workos/constants.ts
@@ -5,12 +5,16 @@ export const STORE_KEYS = {
   apiKeyMap: 'apiKeyMap',
   jwtTemplate: 'jwt_template',
   interactiveAuth: 'interactiveAuth',
+  /** Set alongside interactiveAuth when the AuthKit login page should also ask for a password. */
+  interactivePassword: 'interactivePassword',
   allowedRedirectHosts: 'allowedRedirectHosts',
 } as const;
 
 /** Prefix for dynamic store keys */
 export const STORE_KEY_PREFIXES = {
   pendingAuth: 'pending_auth:',
+  /** A password the interactive page has checked, carried across the organization page instead of the password itself. */
+  interactiveLogin: 'interactive_login:',
   ssoToken: 'sso_token:',
   ssoLogout: 'sso_logout:',
   auditSchema: 'audit_schema_',

--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -140,6 +140,13 @@ export interface WorkOSAuthorizationCode extends Entity {
   code_challenge_method: string | null;
   /** The OAuth client that initiated the authorization, bound to the code so the token claim can't be spoofed at redemption. */
   client_id: string | null;
+  /**
+   * How the user proved who they were on the way to this code, when the emulator knows. The
+   * interactive password page records 'Password'; the default auto-redirect checks nothing and
+   * leaves this null, so the exchange reports the OAuth grant it always has rather than a method
+   * nobody verified.
+   */
+  auth_method: string | null;
 }
 
 export interface WorkOSIdentity extends Entity {

--- a/src/workos/entities.ts
+++ b/src/workos/entities.ts
@@ -147,6 +147,13 @@ export interface WorkOSAuthorizationCode extends Entity {
    * nobody verified.
    */
   auth_method: string | null;
+  /**
+   * The gate the interactive login cleared last on the way to this code — 'EmailVerification' or
+   * 'MFA' — when it had to clear one. The exchange then reports what the API grant for that step
+   * reports: the gate's event, with the session recording `auth_method` as the primary. Null when
+   * the password alone earned the code, and always null from the auto-redirect.
+   */
+  step_up_method: string | null;
 }
 
 export interface WorkOSIdentity extends Entity {

--- a/src/workos/helpers.ts
+++ b/src/workos/helpers.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash, createCipheriv } from 'node:crypto';
+import { randomBytes, createHash } from 'node:crypto';
 import { isIPv6 } from 'node:net';
 import { domainToASCII } from 'node:url';
 import {
@@ -1080,17 +1080,4 @@ export function formatWebhookEndpoint(
     created_at: ep.created_at,
     updated_at: ep.updated_at,
   };
-}
-
-export function sealSession(
-  data: { access_token: string; refresh_token: string; session_id: string },
-  apiKey: string,
-): string {
-  const key = createHash('sha256').update(apiKey).digest();
-  const iv = randomBytes(12);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
-  const plaintext = JSON.stringify(data);
-  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  return Buffer.concat([iv, tag, encrypted]).toString('base64');
 }

--- a/src/workos/interactive-auth.spec.ts
+++ b/src/workos/interactive-auth.spec.ts
@@ -374,6 +374,24 @@ describe('Interactive Auth Mode with the password step', () => {
     expect(body.organization_id).toBe(orgId);
   });
 
+  it('sweeps the token of an abandoned organization page once it has expired', async () => {
+    const abandoned = await submit({ email: 'multi@example.com', password: 'correct-horse' });
+    expect(abandoned.status).toBe(200);
+    const token = (await abandoned.text()).match(/name="pending_authentication_token" value="([^"]+)"/)?.[1] ?? '';
+    expect(token).not.toBe('');
+    const key = `${STORE_KEY_PREFIXES.interactiveLogin}${token}`;
+    const stored = emulator.store.getData<{ expires_at: string }>(key);
+    expect(stored).toBeDefined();
+    // Age it past its ten minutes without waiting them out.
+    emulator.store.setData(key, { ...stored, expires_at: new Date(Date.now() - 1000).toISOString() });
+
+    // The next login that mints a token sweeps the stale one and keeps only its own.
+    const next = await submit({ email: 'multi@example.com', password: 'correct-horse' });
+    expect(next.status).toBe(200);
+    expect(emulator.store.getData(key)).toBeUndefined();
+    expect(emulator.store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin)).toBe(1);
+  });
+
   it('is off under plain interactiveAuth: true, which stays one step', async () => {
     const plain = await createEmulator({
       port: 0,

--- a/src/workos/interactive-auth.spec.ts
+++ b/src/workos/interactive-auth.spec.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { createEmulator, type Emulator } from '../index.js';
+import { getWorkOSStore } from './store.js';
 
 describe('Interactive Auth Mode', () => {
   let emulator: Emulator;
@@ -200,6 +201,211 @@ describe('Interactive Auth Mode after reset()', () => {
       expect(after.headers.get('content-type')).toContain('text/html');
     } finally {
       await emulator.close();
+    }
+  });
+});
+
+/**
+ * The opt-in password step. Plain interactive mode stays one form fill per login; only
+ * `interactiveAuth: { password: true }` puts a password page between the email and the code.
+ */
+describe('Interactive Auth Mode with the password step', () => {
+  let emulator: Emulator;
+  const CALLBACK = 'http://localhost:3000/callback';
+
+  const submit = (fields: Record<string, string>) =>
+    fetch(`${emulator.url}/user_management/authorize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ redirect_uri: CALLBACK, state: 's1', client_id: 'client_test', ...fields }),
+      redirect: 'manual',
+    });
+
+  const exchange = async (location: string) => {
+    const code = new URL(location).searchParams.get('code');
+    const res = await fetch(`${emulator.url}/user_management/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grant_type: 'authorization_code', code, client_id: 'client_test' }),
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()) as Record<string, any>;
+  };
+
+  const authEvents = () =>
+    getWorkOSStore(emulator.store)
+      .events.all()
+      .filter((e: { event: string }) => e.event.startsWith('authentication.'))
+      .map((e: { event: string; data: Record<string, unknown> }) => ({ event: e.event, data: e.data }));
+
+  beforeAll(async () => {
+    emulator = await createEmulator({
+      port: 0,
+      interactiveAuth: { password: true },
+      seed: {
+        users: [
+          { email: 'locked@example.com', password: 'correct-horse' },
+          { email: 'open@example.com' },
+          { email: 'multi@example.com', password: 'correct-horse' },
+        ],
+        organizations: [
+          { name: 'Alpha', memberships: [{ email: 'multi@example.com' }] },
+          { name: 'Beta', memberships: [{ email: 'multi@example.com' }] },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  it('asks a user who has a password for it after the email, instead of minting a code', async () => {
+    const res = await submit({ email: 'locked@example.com' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const html = await res.text();
+    expect(html).toContain('name="password"');
+    // The email travels as a hidden field so the POST checks against the same account.
+    expect(html).toContain('name="email" value="locked@example.com"');
+    // And the way back keeps the authorize parameters without the address.
+    expect(html).toMatch(/href="\/user_management\/authorize\?redirect_uri=[^"]*state=s1[^"]*"/);
+    expect(html).not.toMatch(/href="[^"]*email=/);
+  });
+
+  it('skips the page for a user without a password', async () => {
+    const res = await submit({ email: 'open@example.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('code=');
+  });
+
+  it('re-renders with an inline error on a wrong password and emits authentication.password_failed', async () => {
+    const before = authEvents().length;
+    const res = await submit({ email: 'locked@example.com', password: 'not-the-password' });
+    expect(res.status).toBe(401);
+    const html = await res.text();
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('name="password"');
+    expect(html).not.toContain('not-the-password');
+
+    const failed = authEvents().slice(before);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].event).toBe('authentication.password_failed');
+    expect(failed[0].data).toMatchObject({ email: 'locked@example.com', error: { code: 'invalid_credentials' } });
+  });
+
+  it('mints a code after the right password, and the exchange reports Password', async () => {
+    const before = authEvents().length;
+    const res = await submit({ email: 'locked@example.com', password: 'correct-horse' });
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain(`${CALLBACK}?code=`);
+    expect(location).toContain('state=s1');
+
+    const body = await exchange(location);
+    expect(body.user.email).toBe('locked@example.com');
+    expect(body.authentication_method).toBe('Password');
+
+    const events = authEvents()
+      .slice(before)
+      .map((e) => e.event);
+    expect(events).toEqual(['authentication.password_succeeded']);
+  });
+
+  it('asks for the organization after the password, carrying a token rather than the password', async () => {
+    const first = await submit({ email: 'multi@example.com' });
+    expect(first.status).toBe(200);
+    const firstHtml = await first.text();
+    expect(firstHtml).toContain('name="password"');
+    expect(firstHtml).not.toContain('Select an organization');
+
+    const second = await submit({ email: 'multi@example.com', password: 'correct-horse' });
+    expect(second.status).toBe(200);
+    const orgHtml = await second.text();
+    expect(orgHtml).toContain('Select an organization');
+    expect(orgHtml).not.toContain('correct-horse');
+    const token = orgHtml.match(/name="pending_authentication_token" value="([^"]+)"/)?.[1] ?? '';
+    expect(token).not.toBe('');
+    const orgId = orgHtml.match(/name="organization_id" value="([^"]+)"/)?.[1] ?? '';
+    expect(orgId).not.toBe('');
+
+    const third = await submit({
+      email: 'multi@example.com',
+      organization_id: orgId,
+      pending_authentication_token: token,
+    });
+    expect(third.status).toBe(302);
+    const body = await exchange(third.headers.get('location') ?? '');
+    expect(body.organization_id).toBe(orgId);
+    expect(body.authentication_method).toBe('Password');
+
+    // Spent: presenting the same token again lands back on the password page.
+    const replay = await submit({
+      email: 'multi@example.com',
+      organization_id: orgId,
+      pending_authentication_token: token,
+    });
+    expect(replay.status).toBe(200);
+    expect(await replay.text()).toContain('name="password"');
+  });
+
+  it('sends an organization choice that arrives without a verified login back to the password page', async () => {
+    const list = await fetch(`${emulator.url}/organizations`, {
+      headers: { Authorization: `Bearer ${emulator.apiKey}` },
+    });
+    const orgId = ((await list.json()) as { data: Array<{ id: string }> }).data[0].id;
+
+    const bypass = await submit({ email: 'multi@example.com', organization_id: orgId });
+    expect(bypass.status).toBe(200);
+    const html = await bypass.text();
+    expect(html).toContain('name="password"');
+    // The pre-selected organization survives the detour.
+    expect(html).toContain(`name="organization_id" value="${orgId}"`);
+
+    const done = await submit({ email: 'multi@example.com', organization_id: orgId, password: 'correct-horse' });
+    expect(done.status).toBe(302);
+    const body = await exchange(done.headers.get('location') ?? '');
+    expect(body.organization_id).toBe(orgId);
+  });
+
+  it('is off under plain interactiveAuth: true, which stays one step', async () => {
+    const plain = await createEmulator({
+      port: 0,
+      interactiveAuth: true,
+      seed: { users: [{ email: 'plain@example.com', password: 'pw' }] },
+    });
+    try {
+      const res = await fetch(`${plain.url}/user_management/authorize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ redirect_uri: CALLBACK, email: 'plain@example.com' }),
+        redirect: 'manual',
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('code=');
+    } finally {
+      await plain.close();
+    }
+  });
+
+  it('survives reset()', async () => {
+    const own = await createEmulator({
+      port: 0,
+      interactiveAuth: { password: true },
+      seed: { users: [{ email: 'again@example.com', password: 'pw' }] },
+    });
+    try {
+      own.reset();
+      const res = await fetch(`${own.url}/user_management/authorize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ redirect_uri: CALLBACK, email: 'again@example.com' }),
+        redirect: 'manual',
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain('name="password"');
+    } finally {
+      await own.close();
     }
   });
 });

--- a/src/workos/interactive-auth.spec.ts
+++ b/src/workos/interactive-auth.spec.ts
@@ -417,6 +417,35 @@ describe('Interactive Auth Mode with the password step', () => {
     expect(emulator.store.getData(loginKey(tokenIn(await next.text())))).toBeDefined();
   });
 
+  it('sweeps the verification an abandoned email page was waiting on, along with its token', async () => {
+    const ws = getWorkOSStore(emulator.store);
+    const token = tokenIn(await (await submit({ email: 'unverified@example.com', password: 'correct-horse' })).text());
+    expect(token).not.toBe('');
+    const verificationId = loginFor(token)?.email_verification_id ?? '';
+    expect(ws.emailVerifications.get(verificationId)).toBeDefined();
+    const stored = emulator.store.getData<{ expires_at: string }>(loginKey(token));
+    emulator.store.setData(loginKey(token), { ...stored, expires_at: new Date(Date.now() - 1000).toISOString() });
+
+    // The sweep at the next mint takes the record the gate was waiting on along with the token.
+    expect((await submit({ email: 'multi@example.com', password: 'correct-horse' })).status).toBe(200);
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+    expect(ws.emailVerifications.get(verificationId)).toBeUndefined();
+  });
+
+  it('sweeps the challenge an abandoned one-time-code page was waiting on, along with its token', async () => {
+    const ws = getWorkOSStore(emulator.store);
+    const token = tokenIn(await (await submit({ email: 'mfa@example.com', password: 'correct-horse' })).text());
+    expect(token).not.toBe('');
+    const challengeId = loginFor(token)?.challenge_id ?? '';
+    expect(ws.authChallenges.get(challengeId)).toBeDefined();
+    const stored = emulator.store.getData<{ expires_at: string }>(loginKey(token));
+    emulator.store.setData(loginKey(token), { ...stored, expires_at: new Date(Date.now() - 1000).toISOString() });
+
+    expect((await submit({ email: 'multi@example.com', password: 'correct-horse' })).status).toBe(200);
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+    expect(ws.authChallenges.get(challengeId)).toBeUndefined();
+  });
+
   it('rejects a token minted for another user and asks for the password', async () => {
     const theirs = await submit({ email: 'multi@example.com', password: 'correct-horse' });
     const token = tokenIn(await theirs.text());
@@ -446,6 +475,21 @@ describe('Interactive Auth Mode with the password step', () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('name="password"');
     expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+  });
+
+  it('drops the challenge along with an expired token that is presented again', async () => {
+    const ws = getWorkOSStore(emulator.store);
+    const token = tokenIn(await (await submit({ email: 'mfa@example.com', password: 'correct-horse' })).text());
+    const challengeId = loginFor(token)?.challenge_id ?? '';
+    expect(ws.authChallenges.get(challengeId)).toBeDefined();
+    const stored = emulator.store.getData<{ expires_at: string }>(loginKey(token));
+    emulator.store.setData(loginKey(token), { ...stored, expires_at: new Date(Date.now() - 1000).toISOString() });
+
+    const res = await submit({ email: 'mfa@example.com', pending_authentication_token: token });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('name="password"');
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+    expect(ws.authChallenges.get(challengeId)).toBeUndefined();
   });
 
   it('asks an unverified user for the emailed code after the password, before minting anything', async () => {

--- a/src/workos/interactive-auth.spec.ts
+++ b/src/workos/interactive-auth.spec.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { createEmulator, type Emulator } from '../index.js';
 import { getWorkOSStore } from './store.js';
+import { STORE_KEY_PREFIXES } from './constants.js';
 
 describe('Interactive Auth Mode', () => {
   let emulator: Emulator;
@@ -338,6 +339,11 @@ describe('Interactive Auth Mode with the password step', () => {
     const body = await exchange(third.headers.get('location') ?? '');
     expect(body.organization_id).toBe(orgId);
     expect(body.authentication_method).toBe('Password');
+
+    // Spent means gone: the entry is removed, not left behind holding `undefined`, so a
+    // long-lived emulator does not grow by one key per login. The prefix sweep reports how
+    // many entries it found; zero is the point.
+    expect(emulator.store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin)).toBe(0);
 
     // Spent: presenting the same token again lands back on the password page.
     const replay = await submit({

--- a/src/workos/interactive-auth.spec.ts
+++ b/src/workos/interactive-auth.spec.ts
@@ -239,19 +239,45 @@ describe('Interactive Auth Mode with the password step', () => {
       .filter((e: { event: string }) => e.event.startsWith('authentication.'))
       .map((e: { event: string; data: Record<string, unknown> }) => ({ event: e.event, data: e.data }));
 
+  const tokenIn = (html: string) => html.match(/name="pending_authentication_token" value="([^"]+)"/)?.[1] ?? '';
+  const loginKey = (token: string) => `${STORE_KEY_PREFIXES.interactiveLogin}${token}`;
+  /** The login a page's token stands for, as the emulator stores it. */
+  const loginFor = (token: string) =>
+    emulator.store.getData<{ email_verification_id: string | null; challenge_id: string | null }>(loginKey(token));
+  /** The emailed code the verification page waits for: the one the email_verification.created webhook carried. */
+  const emailCodeFor = (token: string) =>
+    getWorkOSStore(emulator.store).emailVerifications.get(loginFor(token)?.email_verification_id ?? '')?.code ?? '';
+  /** The authenticator code the one-time-code page waits for, read from the stored challenge as the mfa-totp grant's tests do. */
+  const challengeCodeFor = (token: string) =>
+    getWorkOSStore(emulator.store).authChallenges.get(loginFor(token)?.challenge_id ?? '')?.code ?? '';
+  const createUser = async (email: string, body: Record<string, unknown>) => {
+    const res = await fetch(`${emulator.url}/user_management/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${emulator.apiKey}` },
+      body: JSON.stringify({ email, ...body }),
+    });
+    expect(res.status).toBe(201);
+  };
+
   beforeAll(async () => {
     emulator = await createEmulator({
       port: 0,
       interactiveAuth: { password: true },
       seed: {
         users: [
-          { email: 'locked@example.com', password: 'correct-horse' },
+          // Seeds default to an unverified mailbox, which is the first gate after the password;
+          // these are verified so they go from the password straight to what follows it.
+          { email: 'locked@example.com', password: 'correct-horse', email_verified: true },
           { email: 'open@example.com' },
-          { email: 'multi@example.com', password: 'correct-horse' },
+          { email: 'multi@example.com', password: 'correct-horse', email_verified: true },
+          { email: 'unverified@example.com', password: 'correct-horse' },
+          { email: 'mfa@example.com', password: 'correct-horse', email_verified: true, totp: true },
+          // Every gate at once: an unverified mailbox, a second factor, and two organizations.
+          { email: 'gated@example.com', password: 'correct-horse', totp: true },
         ],
         organizations: [
-          { name: 'Alpha', memberships: [{ email: 'multi@example.com' }] },
-          { name: 'Beta', memberships: [{ email: 'multi@example.com' }] },
+          { name: 'Alpha', memberships: [{ email: 'multi@example.com' }, { email: 'gated@example.com' }] },
+          { name: 'Beta', memberships: [{ email: 'multi@example.com' }, { email: 'gated@example.com' }] },
         ],
       },
     });
@@ -341,9 +367,8 @@ describe('Interactive Auth Mode with the password step', () => {
     expect(body.authentication_method).toBe('Password');
 
     // Spent means gone: the entry is removed, not left behind holding `undefined`, so a
-    // long-lived emulator does not grow by one key per login. The prefix sweep reports how
-    // many entries it found; zero is the point.
-    expect(emulator.store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin)).toBe(0);
+    // long-lived emulator does not grow by one key per login.
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
 
     // Spent: presenting the same token again lands back on the password page.
     const replay = await submit({
@@ -385,11 +410,227 @@ describe('Interactive Auth Mode with the password step', () => {
     // Age it past its ten minutes without waiting them out.
     emulator.store.setData(key, { ...stored, expires_at: new Date(Date.now() - 1000).toISOString() });
 
-    // The next login that mints a token sweeps the stale one and keeps only its own.
+    // The next login that mints a token sweeps the stale one and keeps its own.
     const next = await submit({ email: 'multi@example.com', password: 'correct-horse' });
     expect(next.status).toBe(200);
     expect(emulator.store.getData(key)).toBeUndefined();
-    expect(emulator.store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin)).toBe(1);
+    expect(emulator.store.getData(loginKey(tokenIn(await next.text())))).toBeDefined();
+  });
+
+  it('rejects a token minted for another user and asks for the password', async () => {
+    const theirs = await submit({ email: 'multi@example.com', password: 'correct-horse' });
+    const token = tokenIn(await theirs.text());
+    expect(token).not.toBe('');
+
+    const res = await submit({ email: 'locked@example.com', pending_authentication_token: token });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('name="password"');
+    // Theirs is still theirs: a mismatch neither spends nor drops it.
+    expect(emulator.store.getData(loginKey(token))).toBeDefined();
+  });
+
+  it('drops an expired token that is presented again and asks for the password', async () => {
+    const page = await submit({ email: 'multi@example.com', password: 'correct-horse' });
+    const html = await page.text();
+    const token = tokenIn(html);
+    const orgId = html.match(/name="organization_id" value="([^"]+)"/)?.[1] ?? '';
+    const stored = emulator.store.getData<{ expires_at: string }>(loginKey(token));
+    expect(stored).toBeDefined();
+    emulator.store.setData(loginKey(token), { ...stored, expires_at: new Date(Date.now() - 1000).toISOString() });
+
+    const res = await submit({
+      email: 'multi@example.com',
+      organization_id: orgId,
+      pending_authentication_token: token,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('name="password"');
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+  });
+
+  it('asks an unverified user for the emailed code after the password, before minting anything', async () => {
+    const events = getWorkOSStore(emulator.store).events;
+    const before = events.all().length;
+    const res = await submit({ email: 'unverified@example.com', password: 'correct-horse' });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Verify your email');
+    expect(html).toContain('name="code"');
+    expect(html).not.toContain('correct-horse');
+    const token = tokenIn(html);
+    expect(token).not.toBe('');
+
+    // The code leaves the emulator the way every emailed code does, and it is the one the page wants.
+    const created = events
+      .all()
+      .slice(before)
+      .filter((e: { event: string }) => e.event === 'email_verification.created');
+    expect(created).toHaveLength(1);
+    expect(emailCodeFor(token)).toMatch(/^\d{6}$/);
+    expect(created[0].data).toMatchObject({ email: 'unverified@example.com', code: emailCodeFor(token) });
+  });
+
+  it('re-renders with an inline error on a wrong emailed code and emits authentication.email_verification_failed', async () => {
+    const token = tokenIn(await (await submit({ email: 'unverified@example.com', password: 'correct-horse' })).text());
+    const before = authEvents().length;
+    const res = await submit({ email: 'unverified@example.com', pending_authentication_token: token, code: '000000' });
+    expect(res.status).toBe(401);
+    const html = await res.text();
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('name="code"');
+
+    const failed = authEvents().slice(before);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].event).toBe('authentication.email_verification_failed');
+    expect(failed[0].data).toMatchObject({ email: 'unverified@example.com', error: { code: 'invalid_code' } });
+    // The same code is still waiting; a wrong guess does not reissue it.
+    expect(emailCodeFor(token)).toMatch(/^\d{6}$/);
+  });
+
+  it('verifies the email for good after the right code; the exchange reports what the email-verification grant would', async () => {
+    await createUser('verified-by-code@example.com', { password: 'correct-horse' });
+    const token = tokenIn(
+      await (await submit({ email: 'verified-by-code@example.com', password: 'correct-horse' })).text(),
+    );
+    const before = authEvents().length;
+
+    const res = await submit({
+      email: 'verified-by-code@example.com',
+      pending_authentication_token: token,
+      code: emailCodeFor(token),
+    });
+    expect(res.status).toBe(302);
+    const body = await exchange(res.headers.get('location') ?? '');
+    expect(body.user.email_verified).toBe(true);
+    expect(body.authentication_method).toBe('Password');
+    // The gate's event, with the session recording the password it gated: the same pair the
+    // urn:workos:oauth:grant-type:email-verification:code grant produces for this login.
+    expect(
+      authEvents()
+        .slice(before)
+        .map((e) => e.event),
+    ).toEqual(['authentication.email_verification_succeeded']);
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+
+    // Verified once is verified: the next login goes from the password straight to the callback.
+    const again = await submit({ email: 'verified-by-code@example.com', password: 'correct-horse' });
+    expect(again.status).toBe(302);
+  });
+
+  it('asks a user with an enrolled factor for the one-time code after the password', async () => {
+    const res = await submit({ email: 'mfa@example.com', password: 'correct-horse' });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Enter your one-time code');
+    expect(html).toContain('name="code"');
+    const token = tokenIn(html);
+    expect(token).not.toBe('');
+    // A challenge for the enrolled factor: the record the password grant's mfa_challenge step creates.
+    expect(challengeCodeFor(token)).toMatch(/^\d{6}$/);
+
+    // Asking for the page again keeps the same challenge rather than minting another.
+    const challengeId = loginFor(token)?.challenge_id;
+    const again = await submit({ email: 'mfa@example.com', pending_authentication_token: token });
+    expect(again.status).toBe(200);
+    expect(loginFor(token)?.challenge_id).toBe(challengeId);
+  });
+
+  it('re-renders with an inline error on a wrong one-time code and emits authentication.mfa_failed', async () => {
+    const token = tokenIn(await (await submit({ email: 'mfa@example.com', password: 'correct-horse' })).text());
+    const before = authEvents().length;
+    const res = await submit({ email: 'mfa@example.com', pending_authentication_token: token, code: '000000' });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain('role="alert"');
+
+    const failed = authEvents().slice(before);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].event).toBe('authentication.mfa_failed');
+    expect(failed[0].data).toMatchObject({ email: 'mfa@example.com', error: { code: 'invalid_one_time_code' } });
+  });
+
+  it('mints a code after the right one-time code; the exchange reports what the mfa-totp grant would', async () => {
+    const token = tokenIn(await (await submit({ email: 'mfa@example.com', password: 'correct-horse' })).text());
+    const challengeId = loginFor(token)?.challenge_id ?? '';
+    const before = authEvents().length;
+
+    const res = await submit({
+      email: 'mfa@example.com',
+      pending_authentication_token: token,
+      code: challengeCodeFor(token),
+    });
+    expect(res.status).toBe(302);
+    const body = await exchange(res.headers.get('location') ?? '');
+    expect(body.authentication_method).toBe('Password');
+    expect(
+      authEvents()
+        .slice(before)
+        .map((e) => e.event),
+    ).toEqual(['authentication.mfa_succeeded']);
+    // Challenge and token are both spent.
+    expect(getWorkOSStore(emulator.store).authChallenges.get(challengeId)).toBeUndefined();
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
+  });
+
+  it('runs the emailed code, then the second factor, then the organization page, under one token', async () => {
+    const first = await submit({ email: 'gated@example.com', password: 'correct-horse' });
+    const firstHtml = await first.text();
+    expect(firstHtml).toContain('Verify your email');
+    const token = tokenIn(firstHtml);
+    expect(token).not.toBe('');
+
+    const second = await submit({
+      email: 'gated@example.com',
+      pending_authentication_token: token,
+      code: emailCodeFor(token),
+    });
+    expect(second.status).toBe(200);
+    const secondHtml = await second.text();
+    expect(secondHtml).toContain('Enter your one-time code');
+    expect(tokenIn(secondHtml)).toBe(token);
+
+    // An organization choice that skips the second factor lands back on it.
+    const list = await fetch(`${emulator.url}/organizations`, {
+      headers: { Authorization: `Bearer ${emulator.apiKey}` },
+    });
+    const alpha = ((await list.json()) as { data: Array<{ id: string; name: string }> }).data.find(
+      (o) => o.name === 'Alpha',
+    )!;
+    const skip = await submit({
+      email: 'gated@example.com',
+      pending_authentication_token: token,
+      organization_id: alpha.id,
+    });
+    expect(skip.status).toBe(200);
+    expect(await skip.text()).toContain('Enter your one-time code');
+
+    const third = await submit({
+      email: 'gated@example.com',
+      pending_authentication_token: token,
+      code: challengeCodeFor(token),
+    });
+    expect(third.status).toBe(200);
+    const thirdHtml = await third.text();
+    expect(thirdHtml).toContain('Select an organization');
+    expect(tokenIn(thirdHtml)).toBe(token);
+
+    const before = authEvents().length;
+    const fourth = await submit({
+      email: 'gated@example.com',
+      pending_authentication_token: token,
+      organization_id: alpha.id,
+    });
+    expect(fourth.status).toBe(302);
+    const body = await exchange(fourth.headers.get('location') ?? '');
+    expect(body.organization_id).toBe(alpha.id);
+    expect(body.user.email_verified).toBe(true);
+    expect(body.authentication_method).toBe('Password');
+    // The gate cleared last is what the exchange reports, as the API's final grant would be.
+    expect(
+      authEvents()
+        .slice(before)
+        .map((e) => e.event),
+    ).toEqual(['authentication.mfa_succeeded']);
+    expect(emulator.store.getData(loginKey(token))).toBeUndefined();
   });
 
   it('is off under plain interactiveAuth: true, which stays one step', async () => {

--- a/src/workos/login-page.ts
+++ b/src/workos/login-page.ts
@@ -231,3 +231,73 @@ function renderHiddenInputs(fields: Record<string, string>): string {
 function esc(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
+
+export interface PasswordPageOptions {
+  /** Who is signing in, shown read-only so the page reads as the second step of one sign-in. */
+  email: string;
+  formAction: string;
+  /** Carried through with `email` included, so the POST checks the password against the account the previous page resolved. */
+  hiddenFields: Record<string, string>;
+  /** Where "Use a different account" leads: the email page, with the same authorize parameters. */
+  backHref: string;
+  /** Shown above the field after a failed attempt. */
+  error?: string;
+}
+
+/**
+ * The screen hosted AuthKit shows a user who has a password: after the email, before any
+ * organization question. Served only when the interactive password option is on, because the
+ * one-step email page is what existing browser suites were written against.
+ *
+ * A failed attempt re-renders this page with the error inline rather than redirecting to the
+ * callback with an error parameter, the way an unknown email does. A mistyped password is
+ * something the user retries on the spot; the application only hears about the login once it
+ * has succeeded. No JavaScript, like the other pages, so a plain form POST is the whole protocol.
+ */
+export function renderPasswordPage(options: PasswordPageOptions): string {
+  const { email, formAction, hiddenFields, backHref, error } = options;
+
+  const hiddenInputs = renderHiddenInputs(hiddenFields);
+  const alert = error ? `\n    <p class="error" role="alert">${esc(error)}</p>` : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Enter your password — WorkOS Emulate</title>
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f5;display:flex;justify-content:center;align-items:center;min-height:100vh}
+    .card{background:#fff;border-radius:8px;padding:40px;width:400px;box-shadow:0 2px 8px rgba(0,0,0,.1)}
+    .badge{display:inline-block;background:#6366f1;color:#fff;font-size:11px;font-weight:600;padding:3px 8px;border-radius:4px;margin-bottom:16px;letter-spacing:.5px}
+    h1{font-size:22px;font-weight:600;margin-bottom:8px}
+    .sub{color:#6b7280;font-size:14px;margin-bottom:24px}
+    .sub strong{color:#111827;font-weight:500}
+    .error{background:#fef2f2;border:1px solid #fecaca;color:#b91c1c;border-radius:6px;padding:10px 12px;font-size:13px;margin-bottom:16px}
+    label{display:block;font-size:14px;font-weight:500;margin-bottom:6px}
+    input[type="password"]{width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:6px;font-size:14px;outline:none}
+    input[type="password"]:focus{border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.1)}
+    input[aria-invalid="true"]{border-color:#f87171}
+    button{width:100%;padding:10px;background:#6366f1;color:#fff;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;margin-top:16px}
+    button:hover{background:#4f46e5}
+    .switch{display:block;margin-top:20px;font-size:13px;color:#6b7280;text-align:center;text-decoration:none}
+    .switch:hover{color:#111827;text-decoration:underline}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">WORKOS EMULATE</div>
+    <h1>Enter your password</h1>
+    <p class="sub">Signing in as <strong>${esc(email)}</strong>.</p>${alert}
+    <form method="POST" action="${esc(formAction)}">
+        ${hiddenInputs}
+        <label for="password">Password</label>
+        <input type="password" id="password" name="password" required autofocus autocomplete="current-password"${error ? ' aria-invalid="true"' : ''}>
+        <button type="submit">Continue</button>
+    </form>
+    <a class="switch" href="${esc(backHref)}">Use a different account</a>
+  </div>
+</body>
+</html>`;
+}

--- a/src/workos/login-page.ts
+++ b/src/workos/login-page.ts
@@ -266,23 +266,7 @@ export function renderPasswordPage(options: PasswordPageOptions): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Enter your password — WorkOS Emulate</title>
-  <style>
-    *{margin:0;padding:0;box-sizing:border-box}
-    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f5;display:flex;justify-content:center;align-items:center;min-height:100vh}
-    .card{background:#fff;border-radius:8px;padding:40px;width:400px;box-shadow:0 2px 8px rgba(0,0,0,.1)}
-    .badge{display:inline-block;background:#6366f1;color:#fff;font-size:11px;font-weight:600;padding:3px 8px;border-radius:4px;margin-bottom:16px;letter-spacing:.5px}
-    h1{font-size:22px;font-weight:600;margin-bottom:8px}
-    .sub{color:#6b7280;font-size:14px;margin-bottom:24px}
-    .sub strong{color:#111827;font-weight:500}
-    .error{background:#fef2f2;border:1px solid #fecaca;color:#b91c1c;border-radius:6px;padding:10px 12px;font-size:13px;margin-bottom:16px}
-    label{display:block;font-size:14px;font-weight:500;margin-bottom:6px}
-    input[type="password"]{width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:6px;font-size:14px;outline:none}
-    input[type="password"]:focus{border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.1)}
-    input[aria-invalid="true"]{border-color:#f87171}
-    button{width:100%;padding:10px;background:#6366f1;color:#fff;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;margin-top:16px}
-    button:hover{background:#4f46e5}
-    .switch{display:block;margin-top:20px;font-size:13px;color:#6b7280;text-align:center;text-decoration:none}
-    .switch:hover{color:#111827;text-decoration:underline}
+  <style>${STEP_PAGE_STYLE}
   </style>
 </head>
 <body>
@@ -293,7 +277,7 @@ export function renderPasswordPage(options: PasswordPageOptions): string {
     <form method="POST" action="${esc(formAction)}">
         ${hiddenInputs}
         <label for="password">Password</label>
-        <input type="password" id="password" name="password" required autofocus autocomplete="current-password"${error ? ' aria-invalid="true"' : ''}>
+        <input type="password" class="field" id="password" name="password" required autofocus autocomplete="current-password"${error ? ' aria-invalid="true"' : ''}>
         <button type="submit">Continue</button>
     </form>
     <a class="switch" href="${esc(backHref)}">Use a different account</a>
@@ -301,3 +285,77 @@ export function renderPasswordPage(options: PasswordPageOptions): string {
 </body>
 </html>`;
 }
+
+export interface CodePageOptions {
+  title: string;
+  /** The sentence that introduces the address, e.g. "Enter the code we sent to". */
+  lead: string;
+  /** Who is signing in, shown read-only as on the password page. */
+  email: string;
+  formAction: string;
+  /** Carried through with `email` and the login token, so the POST resumes the same login. */
+  hiddenFields: Record<string, string>;
+  /** Where "Use a different account" leads: the email page, with the same authorize parameters. */
+  backHref: string;
+  /** Shown above the field after a failed attempt. */
+  error?: string;
+}
+
+/**
+ * The one-time-code screen hosted AuthKit shows between a correct password and a session while
+ * the account still has something to prove: the emailed code for an unverified mailbox, or the
+ * authenticator code for an enrolled second factor. Served by the interactive password option
+ * only, because those are the gates the `password` grant enforces and this page is how the
+ * browser flow enforces the same ones. A failed attempt re-renders inline, as the password page
+ * does and for the same reason.
+ */
+export function renderCodePage(options: CodePageOptions): string {
+  const { title, lead, email, formAction, hiddenFields, backHref, error } = options;
+
+  const hiddenInputs = renderHiddenInputs(hiddenFields);
+  const alert = error ? `\n    <p class="error" role="alert">${esc(error)}</p>` : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${esc(title)} — WorkOS Emulate</title>
+  <style>${STEP_PAGE_STYLE}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">WORKOS EMULATE</div>
+    <h1>${esc(title)}</h1>
+    <p class="sub">${esc(lead)} <strong>${esc(email)}</strong>.</p>${alert}
+    <form method="POST" action="${esc(formAction)}">
+        ${hiddenInputs}
+        <label for="code">Code</label>
+        <input type="text" class="field" id="code" name="code" inputmode="numeric" autocomplete="one-time-code" required autofocus${error ? ' aria-invalid="true"' : ''}>
+        <button type="submit">Continue</button>
+    </form>
+    <a class="switch" href="${esc(backHref)}">Use a different account</a>
+  </div>
+</body>
+</html>`;
+}
+
+/** The styles every page after the email shares: one card, one field, one button, a way back. */
+const STEP_PAGE_STYLE = `
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f5;display:flex;justify-content:center;align-items:center;min-height:100vh}
+    .card{background:#fff;border-radius:8px;padding:40px;width:400px;box-shadow:0 2px 8px rgba(0,0,0,.1)}
+    .badge{display:inline-block;background:#6366f1;color:#fff;font-size:11px;font-weight:600;padding:3px 8px;border-radius:4px;margin-bottom:16px;letter-spacing:.5px}
+    h1{font-size:22px;font-weight:600;margin-bottom:8px}
+    .sub{color:#6b7280;font-size:14px;margin-bottom:24px}
+    .sub strong{color:#111827;font-weight:500}
+    .error{background:#fef2f2;border:1px solid #fecaca;color:#b91c1c;border-radius:6px;padding:10px 12px;font-size:13px;margin-bottom:16px}
+    label{display:block;font-size:14px;font-weight:500;margin-bottom:6px}
+    .field{width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:6px;font-size:14px;outline:none}
+    .field:focus{border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.1)}
+    .field[aria-invalid="true"]{border-color:#f87171}
+    button{width:100%;padding:10px;background:#6366f1;color:#fff;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;margin-top:16px}
+    button:hover{background:#4f46e5}
+    .switch{display:block;margin-top:20px;font-size:13px;color:#6b7280;text-align:center;text-decoration:none}
+    .switch:hover{color:#111827;text-decoration:underline}`;

--- a/src/workos/routes/auth.spec.ts
+++ b/src/workos/routes/auth.spec.ts
@@ -840,8 +840,13 @@ describe('Auth routes', () => {
   });
 
   // --- Sealed session tests ---
+  // Production never returns sealed_session for API requests: session sealing is done
+  // client-side by the SDKs with a caller-supplied cookie password the server never sees.
+  // A non-null value here pushes authkit-nextjs session cookies past the 4096-byte browser
+  // cap (issue #93), so the field is always null regardless of which credentials the
+  // request carries.
 
-  it('returns sealed_session when client_secret provided', async () => {
+  it('returns sealed_session: null even when client_secret is provided', async () => {
     await req('/user_management/users', {
       method: 'POST',
       body: JSON.stringify({ email: 'sealed@test.com', password: 'pw', email_verified: true }),
@@ -858,8 +863,46 @@ describe('Auth routes', () => {
       }),
     });
     const body = await json(res);
-    expect(body.sealed_session).toBeTruthy();
-    expect(typeof body.sealed_session).toBe('string');
+    expect(body.sealed_session).toBeNull();
+  });
+
+  it('returns sealed_session: null for the SDK refresh-token call shape', async () => {
+    // @workos-inc/node's authenticateWithRefreshToken sends both an Authorization: Bearer
+    // header (the API key) and the same key as client_secret in the body — exactly the
+    // shape that used to opt into sealing via `clientSecret ?? apiKey`.
+    await req('/user_management/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'sealed-refresh@test.com', password: 'pw', email_verified: true }),
+    });
+
+    const authRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'password',
+        client_id: 'test_client',
+        email: 'sealed-refresh@test.com',
+        password: 'pw',
+      }),
+    });
+    expect(authRes.status).toBe(200);
+    const authBody = await json(authRes);
+
+    const refreshRes = await app.request('/user_management/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer sk_test_auth' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: authBody.refresh_token,
+        client_id: 'test_client',
+        client_secret: 'sk_test_auth',
+      }),
+    });
+    expect(refreshRes.status).toBe(200);
+    const refreshBody = await json(refreshRes);
+    expect(refreshBody.sealed_session).toBeNull();
+    expect(refreshBody.access_token).toBeTruthy();
+    expect(refreshBody.refresh_token).toBeTruthy();
   });
 
   // --- Grant type alias tests ---

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -200,16 +200,29 @@ export function authRoutes(ctx: RouteContext): void {
     // The token `login` is stored under, once a page after the password has needed one.
     let loginToken: string | null = null;
     /**
+     * Drop the record an expired login's open gate was waiting on: the email_verification or
+     * authentication_challenge only that login could have redeemed. Otherwise every abandoned
+     * gated login would keep one such record for the emulator's lifetime after its token went.
+     */
+    const releaseGate = (stale: InteractiveLogin) => {
+      if (stale.email_verification_id) ws.emailVerifications.delete(stale.email_verification_id);
+      if (stale.challenge_id) ws.authChallenges.delete(stale.challenge_id);
+    };
+    /**
      * Persist `login` under its token for the page about to be served, minting the token the
      * first time. A page that is never submitted leaves its token behind, and nothing would
-     * present it again to trip the expiry check, so expired entries are swept at each mint: the
-     * store holds at most the tokens from the last ten minutes rather than one per abandoned login.
+     * present it again to trip the expiry check, so expired entries are swept at each mint, each
+     * with the gate record it references: the store holds at most the logins from the last ten
+     * minutes rather than one per abandoned login.
      */
     const carryLogin = (): string => {
       if (!loginToken) {
-        store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin, (v) =>
-          isExpired((v as InteractiveLogin).expires_at),
-        );
+        store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin, (v) => {
+          const stale = v as InteractiveLogin;
+          if (!isExpired(stale.expires_at)) return false;
+          releaseGate(stale);
+          return true;
+        });
         loginToken = generateId('pending');
       }
       store.setData(`${STORE_KEY_PREFIXES.interactiveLogin}${loginToken}`, login);
@@ -220,7 +233,9 @@ export function authRoutes(ctx: RouteContext): void {
       const key = pendingToken ? `${STORE_KEY_PREFIXES.interactiveLogin}${pendingToken}` : null;
       let verified = key ? store.getData<InteractiveLogin>(key) : undefined;
       if (key && verified && isExpired(verified.expires_at)) {
-        // Nothing will ever redeem an expired token, so drop it rather than leave it behind.
+        // Nothing will ever redeem an expired token, so drop it, and the record its gate was
+        // waiting on, rather than leave them behind.
+        releaseGate(verified);
         store.deleteData(key);
         verified = undefined;
       }

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -243,6 +243,12 @@ export function authRoutes(ctx: RouteContext): void {
           // after the password, and the check it just passed is what the token records.
           let token = verifiedLoginKey ? pendingToken : null;
           if (!token) {
+            // A page that is never submitted leaves its token behind, and nothing would present
+            // it again to trip the expiry check above. Sweep those here, so the store holds at
+            // most the tokens minted in the last ten minutes rather than one per abandoned login.
+            store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin, (v) =>
+              isExpired((v as InteractiveLogin).expires_at),
+            );
             token = generateId('pending');
             const login: InteractiveLogin = {
               user_id: user.id,

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -38,6 +38,7 @@ import {
   renderDeviceVerifyPage,
   renderOrganizationSelectPage,
   renderPasswordPage,
+  renderCodePage,
 } from '../login-page.js';
 
 interface PendingAuth {
@@ -49,14 +50,24 @@ interface PendingAuth {
 }
 
 /**
- * A password the interactive page has already checked. The organization page that can follow
+ * A password the interactive page has already checked, and how far past it the login has got.
+ * Every page that can follow — email verification, the second factor, the organization choice —
  * carries a token for one of these rather than the password itself, so a secret never sits in a
- * hidden field, and an organization POST that leaves the token out cannot skip the check.
+ * hidden field, and a POST that leaves the token out cannot skip a check.
  */
 interface InteractiveLogin {
   user_id: string;
+  /** The primary method, 'Password': what the session will record. */
   auth_method: string;
   expires_at: string;
+  /** The gate cleared last, 'EmailVerification' or 'MFA', which the exchange reports the way the API grant for it would. */
+  step_up_method: string | null;
+  /** The email_verification whose code the verification page is waiting for, while that gate is open. */
+  email_verification_id: string | null;
+  /** The authentication_challenge whose code the one-time-code page is waiting for, while that gate is open. */
+  challenge_id: string | null;
+  /** Whether the second factor has been cleared for this login; the factor stays enrolled, so the record has to say. */
+  mfa_verified: boolean;
 }
 
 /**
@@ -82,7 +93,9 @@ interface AuthorizeParams {
   organizationId: string | null;
   /** What the interactive password page submitted; null until the form reaches that step. */
   password: string | null;
-  /** Proof from an earlier password page that this login is already verified, carried across the organization page. */
+  /** What a verification page submitted — the emailed or the authenticator code; null until the form reaches such a step. */
+  code: string | null;
+  /** Proof from an earlier password page that this login is already verified, carried across every page after it. */
   pendingToken: string | null;
 }
 
@@ -128,6 +141,7 @@ export function authRoutes(ctx: RouteContext): void {
       clientId,
       organizationId,
       password,
+      code,
       pendingToken,
     } = params;
 
@@ -176,11 +190,32 @@ export function authRoutes(ctx: RouteContext): void {
     // user who has a password is asked: a passwordless account has nothing to check, and a page
     // demanding a secret nobody set would be a dead end rather than fidelity.
     //
-    // A verified login is remembered under a short-lived token rather than re-sent, so the
-    // organization page never carries the password, and an organization POST that arrives
-    // without a valid token lands back on the password page instead of skipping it.
-    let codeAuthMethod: string | null = null;
-    let verifiedLoginKey: string | null = null;
+    // A verified login is remembered under a short-lived token rather than re-sent, so no later
+    // page carries the password, and a POST that arrives without a valid token lands back on the
+    // password page instead of skipping it. The same token carries the login through the gates
+    // the `password` grant puts between a correct password and a session — an unverified
+    // mailbox, then an enrolled second factor — so the browser flow cannot sign in an account
+    // the API would have stopped.
+    let login: InteractiveLogin | null = null;
+    // The token `login` is stored under, once a page after the password has needed one.
+    let loginToken: string | null = null;
+    /**
+     * Persist `login` under its token for the page about to be served, minting the token the
+     * first time. A page that is never submitted leaves its token behind, and nothing would
+     * present it again to trip the expiry check, so expired entries are swept at each mint: the
+     * store holds at most the tokens from the last ten minutes rather than one per abandoned login.
+     */
+    const carryLogin = (): string => {
+      if (!loginToken) {
+        store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin, (v) =>
+          isExpired((v as InteractiveLogin).expires_at),
+        );
+        loginToken = generateId('pending');
+      }
+      store.setData(`${STORE_KEY_PREFIXES.interactiveLogin}${loginToken}`, login);
+      return loginToken;
+    };
+
     if (interactive && store.getData<boolean>(STORE_KEYS.interactivePassword) && user.password_hash) {
       const key = pendingToken ? `${STORE_KEY_PREFIXES.interactiveLogin}${pendingToken}` : null;
       let verified = key ? store.getData<InteractiveLogin>(key) : undefined;
@@ -189,15 +224,33 @@ export function authRoutes(ctx: RouteContext): void {
         store.deleteData(key);
         verified = undefined;
       }
+
+      const fields = carriedFields(params);
+      if (organizationId) fields.organization_id = organizationId;
+      // Back to the email page with the same authorize parameters, minus the address itself:
+      // "a different account" means a different email.
+      const backHref = `/user_management/authorize?${new URLSearchParams(fields).toString()}`;
+      /**
+       * The failure the matching API grant records, so a webhook consumer sees a browser login
+       * fail the way an API one does. The page is then re-rendered rather than the callback
+       * reached: a mistyped secret is something the user retries, not an outcome the app acts on.
+       */
+      const failStep = (method: string, error: { code: string; message: string }) =>
+        emitAuthenticationEvent({
+          eventBus: store.getData<EventBus>(STORE_KEYS.eventBus),
+          method,
+          status: 'failed',
+          userId: user.id,
+          email: user.email,
+          ipAddress: c.req.header('x-forwarded-for') ?? null,
+          userAgent: c.req.header('user-agent') ?? null,
+          error,
+        });
+
       if (verified && verified.user_id === user.id) {
-        codeAuthMethod = verified.auth_method;
-        verifiedLoginKey = key;
+        login = verified;
+        loginToken = pendingToken;
       } else {
-        const fields = carriedFields(params);
-        if (organizationId) fields.organization_id = organizationId;
-        // Back to the email page with the same authorize parameters, minus the address itself:
-        // "a different account" means a different email.
-        const backHref = `/user_management/authorize?${new URLSearchParams(fields).toString()}`;
         const page = (error?: string) =>
           renderPasswordPage({
             email: user.email,
@@ -210,22 +263,119 @@ export function authRoutes(ctx: RouteContext): void {
         if (password === null) return c.html(page());
 
         if (!verifyPassword(password, user.password_hash)) {
-          // The same failure the `password` grant records, so a webhook consumer sees a browser
-          // login fail the way an API one does. Re-rendered rather than sent to the callback: a
-          // mistyped password is something the user retries, not an outcome the app acts on.
-          emitAuthenticationEvent({
-            eventBus: store.getData<EventBus>(STORE_KEYS.eventBus),
-            method: 'Password',
-            status: 'failed',
-            userId: user.id,
-            email: user.email,
-            ipAddress: c.req.header('x-forwarded-for') ?? null,
-            userAgent: c.req.header('user-agent') ?? null,
-            error: { code: 'invalid_credentials', message: `Invalid credentials for '${user.email}'.` },
-          });
+          failStep('Password', { code: 'invalid_credentials', message: `Invalid credentials for '${user.email}'.` });
           return c.html(page('Incorrect password. Try again.'), 401);
         }
-        codeAuthMethod = 'Password';
+        login = {
+          user_id: user.id,
+          auth_method: 'Password',
+          expires_at: expiresIn(10),
+          step_up_method: null,
+          email_verification_id: null,
+          challenge_id: null,
+          mfa_verified: false,
+        };
+      }
+
+      // The gates, in the order hosted AuthKit shows them and the `password` grant checks them:
+      // the unverified mailbox first, since challenging a second factor for an account whose
+      // first contact detail is unproven would hand out a challenge production never issues.
+      // Each is a page that carries the token, so a POST that skips one — an organization
+      // choice, say — lands back on the gate it skipped. A code is spent on the gate it clears.
+      let unspentCode = code;
+      const codePage = (options: { title: string; lead: string; error?: string }) =>
+        c.html(
+          renderCodePage({
+            ...options,
+            email: user.email,
+            formAction: '/user_management/authorize',
+            hiddenFields: { ...fields, email: user.email, pending_authentication_token: carryLogin() },
+            backHref,
+          }),
+          options.error ? 401 : 200,
+        );
+
+      if (!user.email_verified) {
+        const verificationPage = (error?: string) =>
+          codePage({ title: 'Verify your email', lead: 'Enter the code we sent to', error });
+        let pending = login.email_verification_id ? ws.emailVerifications.get(login.email_verification_id) : undefined;
+        let error: string | undefined;
+        if (pending && isExpired(pending.expires_at)) {
+          ws.emailVerifications.delete(pending.id);
+          pending = undefined;
+          if (unspentCode !== null) {
+            failStep('EmailVerification', { code: 'expired_code', message: 'Code has expired' });
+            error = 'That code has expired. A new one has been sent.';
+          }
+        }
+        if (!pending) {
+          // Creating the record is what delivers the code, on the email_verification.created
+          // webhook, the way every emailed code leaves the emulator.
+          pending = ws.emailVerifications.insert({
+            object: 'email_verification',
+            user_id: user.id,
+            email: user.email,
+            code: generateCode(),
+            expires_at: expiresIn(10),
+          });
+          login.email_verification_id = pending.id;
+          return verificationPage(error);
+        }
+        if (unspentCode === null) return verificationPage();
+        if (pending.code !== unspentCode) {
+          failStep('EmailVerification', { code: 'invalid_code', message: 'Invalid code' });
+          return verificationPage('Incorrect code. Try again.');
+        }
+        // What the email-verification grant does with a good code, short of the session it would
+        // issue: the mailbox is proven for good, not only for this login.
+        ws.users.update(user.id, { email_verified: true });
+        ws.emailVerifications.delete(pending.id);
+        login.email_verification_id = null;
+        login.step_up_method = 'EmailVerification';
+        unspentCode = null;
+      }
+
+      const factors = ws.authFactors.findBy('user_id', user.id);
+      if (factors.length > 0 && !login.mfa_verified) {
+        const challengePage = (error?: string) =>
+          codePage({
+            title: 'Enter your one-time code',
+            lead: 'Enter the code from the authenticator enrolled for',
+            error,
+          });
+        let pending = login.challenge_id ? ws.authChallenges.get(login.challenge_id) : undefined;
+        let error: string | undefined;
+        if (pending && isExpired(pending.expires_at)) {
+          ws.authChallenges.delete(pending.id);
+          pending = undefined;
+          if (unspentCode !== null) {
+            failStep('MFA', { code: 'expired_challenge', message: 'Challenge has expired' });
+            error = 'That code has expired. A new challenge has been issued.';
+          }
+        }
+        if (!pending) {
+          // The challenge the `password` grant's mfa_challenge step creates, for the same factor.
+          // Its code is delivered nowhere, as a TOTP code is not; a test reads it from the stored
+          // challenge, as it does to finish the mfa-totp grant.
+          pending = ws.authChallenges.insert({
+            object: 'authentication_challenge',
+            user_id: user.id,
+            factor_id: factors[0].id,
+            expires_at: expiresIn(10),
+            code: generateCode(),
+          });
+          login.challenge_id = pending.id;
+          return challengePage(error);
+        }
+        if (unspentCode === null) return challengePage();
+        if (pending.code && unspentCode !== pending.code) {
+          failStep('MFA', { code: 'invalid_one_time_code', message: 'Invalid one-time code' });
+          return challengePage('Incorrect code. Try again.');
+        }
+        ws.authChallenges.delete(pending.id);
+        login.challenge_id = null;
+        login.mfa_verified = true;
+        login.step_up_method = 'MFA';
       }
     }
 
@@ -238,27 +388,9 @@ export function authRoutes(ctx: RouteContext): void {
       const selectable = activeOrganizationsFor(user.id);
       if (selectable.length > 1) {
         const hiddenFields: Record<string, string> = { ...carriedFields(params), email: user.email };
-        if (codeAuthMethod) {
-          // Reuse the token that got here when there is one; otherwise this is the first page
-          // after the password, and the check it just passed is what the token records.
-          let token = verifiedLoginKey ? pendingToken : null;
-          if (!token) {
-            // A page that is never submitted leaves its token behind, and nothing would present
-            // it again to trip the expiry check above. Sweep those here, so the store holds at
-            // most the tokens minted in the last ten minutes rather than one per abandoned login.
-            store.deleteDataByPrefix(STORE_KEY_PREFIXES.interactiveLogin, (v) =>
-              isExpired((v as InteractiveLogin).expires_at),
-            );
-            token = generateId('pending');
-            const login: InteractiveLogin = {
-              user_id: user.id,
-              auth_method: codeAuthMethod,
-              expires_at: expiresIn(10),
-            };
-            store.setData(`${STORE_KEY_PREFIXES.interactiveLogin}${token}`, login);
-          }
-          hiddenFields.pending_authentication_token = token;
-        }
+        // The verified login rides along under its token, so an organization POST that leaves
+        // it out cannot skip the checks that got here.
+        if (login) hiddenFields.pending_authentication_token = carryLogin();
 
         return c.html(
           renderOrganizationSelectPage({
@@ -280,11 +412,12 @@ export function authRoutes(ctx: RouteContext): void {
       code_challenge: codeChallenge ?? null,
       code_challenge_method: codeChallengeMethod ?? null,
       client_id: clientId,
-      auth_method: codeAuthMethod,
+      auth_method: login?.auth_method ?? null,
+      step_up_method: login?.step_up_method ?? null,
     });
     // One code per verified login: the token is spent once it has minted something. Deleted
     // rather than overwritten, so a long-lived emulator does not keep one entry per login.
-    if (verifiedLoginKey) store.deleteData(verifiedLoginKey);
+    if (loginToken) store.deleteData(`${STORE_KEY_PREFIXES.interactiveLogin}${loginToken}`);
 
     const redirect = new URL(redirectUri);
     redirect.searchParams.set('code', authCode.code);
@@ -346,6 +479,7 @@ export function authRoutes(ctx: RouteContext): void {
       clientId,
       organizationId,
       password: null,
+      code: null,
       pendingToken: null,
     });
   });
@@ -367,6 +501,7 @@ export function authRoutes(ctx: RouteContext): void {
       organizationId: (form.organization_id as string) ?? null,
       // A string, even an empty one, is an attempt; absent means the form has not asked yet.
       password: typeof form.password === 'string' ? form.password : null,
+      code: typeof form.code === 'string' ? form.code : null,
       pendingToken: (form.pending_authentication_token as string) ?? null,
     });
   });
@@ -760,9 +895,13 @@ export function authRoutes(ctx: RouteContext): void {
         // redemption-time request parameter.
         grantClientId = authCode.client_id ?? undefined;
         ws.authCodes.delete(authCode.id);
-        // The interactive password page records how it verified the user; the auto-redirect
-        // verifies nothing and leaves this null, so the grant stays the OAuth it always was.
-        authMethod = authCode.auth_method ?? 'OAuth';
+        // The interactive password page records how it verified the user and, when the login had
+        // a gate to clear on the way, which one came last. The exchange then reports what the API
+        // grant for that step reports: the gate's event, with the session recording the primary
+        // method, exactly as the mfa-totp and email-verification grants leave it. The auto-redirect
+        // verifies nothing and leaves both null, so the grant stays the OAuth it always was.
+        authMethod = authCode.step_up_method ?? authCode.auth_method ?? 'OAuth';
+        if (authCode.step_up_method && authCode.auth_method) sessionAuthMethod = authCode.auth_method;
         break;
       }
 

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -33,7 +33,12 @@ import { renderConfiguredJwtTemplate } from '../jwt-template.js';
 import type { EventBus } from '../event-bus.js';
 import type { WorkOSInvitation, WorkOSSSOAuthorization, WorkOSUser } from '../entities.js';
 import { STORE_KEYS, STORE_KEY_PREFIXES } from '../constants.js';
-import { renderLoginPage, renderDeviceVerifyPage, renderOrganizationSelectPage } from '../login-page.js';
+import {
+  renderLoginPage,
+  renderDeviceVerifyPage,
+  renderOrganizationSelectPage,
+  renderPasswordPage,
+} from '../login-page.js';
 
 interface PendingAuth {
   user_id: string;
@@ -41,6 +46,17 @@ interface PendingAuth {
   auth_method: string;
   /** Carried across an MFA challenge so the second factor doesn't drop a pending invitation. */
   invitation_token?: string | null;
+}
+
+/**
+ * A password the interactive page has already checked. The organization page that can follow
+ * carries a token for one of these rather than the password itself, so a secret never sits in a
+ * hidden field, and an organization POST that leaves the token out cannot skip the check.
+ */
+interface InteractiveLogin {
+  user_id: string;
+  auth_method: string;
+  expires_at: string;
 }
 
 /**
@@ -64,6 +80,10 @@ interface AuthorizeParams {
   clientId: string | null;
   /** Which organization the session should be scoped to, when the caller already knows. */
   organizationId: string | null;
+  /** What the interactive password page submitted; null until the form reaches that step. */
+  password: string | null;
+  /** Proof from an earlier password page that this login is already verified, carried across the organization page. */
+  pendingToken: string | null;
 }
 
 export function authRoutes(ctx: RouteContext): void {
@@ -84,8 +104,32 @@ export function authRoutes(ctx: RouteContext): void {
     return orgs;
   }
 
+  /**
+   * The authorize parameters a page carries through its form, so the POST that follows finishes
+   * the request the GET started. `email` and `organization_id` are added by the pages that know
+   * them.
+   */
+  function carriedFields(params: AuthorizeParams): Record<string, string> {
+    const fields: Record<string, string> = { redirect_uri: params.redirectUri };
+    if (params.state) fields.state = params.state;
+    if (params.codeChallenge) fields.code_challenge = params.codeChallenge;
+    if (params.codeChallengeMethod) fields.code_challenge_method = params.codeChallengeMethod;
+    if (params.clientId) fields.client_id = params.clientId;
+    return fields;
+  }
+
   function resolveAndRedirect(c: any, params: AuthorizeParams) {
-    const { redirectUri, state, codeChallenge, codeChallengeMethod, loginHint, clientId, organizationId } = params;
+    const {
+      redirectUri,
+      state,
+      codeChallenge,
+      codeChallengeMethod,
+      loginHint,
+      clientId,
+      organizationId,
+      password,
+      pendingToken,
+    } = params;
 
     assertAllowedRedirectUri(redirectUri, store);
 
@@ -124,19 +168,86 @@ export function authRoutes(ctx: RouteContext): void {
       );
     }
 
+    const interactive = store.getData<boolean>(STORE_KEYS.interactiveAuth);
+
+    // The password step. Hosted AuthKit asks a user who has a password for it straight after
+    // the email, before any organization question, and that order is kept here. Opt-in, because
+    // the one-step email page is what every existing browser suite was written against. Only a
+    // user who has a password is asked: a passwordless account has nothing to check, and a page
+    // demanding a secret nobody set would be a dead end rather than fidelity.
+    //
+    // A verified login is remembered under a short-lived token rather than re-sent, so the
+    // organization page never carries the password, and an organization POST that arrives
+    // without a valid token lands back on the password page instead of skipping it.
+    let codeAuthMethod: string | null = null;
+    let verifiedLoginKey: string | null = null;
+    if (interactive && store.getData<boolean>(STORE_KEYS.interactivePassword) && user.password_hash) {
+      const key = pendingToken ? `${STORE_KEY_PREFIXES.interactiveLogin}${pendingToken}` : null;
+      const verified = key ? store.getData<InteractiveLogin>(key) : undefined;
+      if (verified && verified.user_id === user.id && !isExpired(verified.expires_at)) {
+        codeAuthMethod = verified.auth_method;
+        verifiedLoginKey = key;
+      } else {
+        const fields = carriedFields(params);
+        if (organizationId) fields.organization_id = organizationId;
+        // Back to the email page with the same authorize parameters, minus the address itself:
+        // "a different account" means a different email.
+        const backHref = `/user_management/authorize?${new URLSearchParams(fields).toString()}`;
+        const page = (error?: string) =>
+          renderPasswordPage({
+            email: user.email,
+            formAction: '/user_management/authorize',
+            hiddenFields: { ...fields, email: user.email },
+            backHref,
+            error,
+          });
+
+        if (password === null) return c.html(page());
+
+        if (!verifyPassword(password, user.password_hash)) {
+          // The same failure the `password` grant records, so a webhook consumer sees a browser
+          // login fail the way an API one does. Re-rendered rather than sent to the callback: a
+          // mistyped password is something the user retries, not an outcome the app acts on.
+          emitAuthenticationEvent({
+            eventBus: store.getData<EventBus>(STORE_KEYS.eventBus),
+            method: 'Password',
+            status: 'failed',
+            userId: user.id,
+            email: user.email,
+            ipAddress: c.req.header('x-forwarded-for') ?? null,
+            userAgent: c.req.header('user-agent') ?? null,
+            error: { code: 'invalid_credentials', message: `Invalid credentials for '${user.email}'.` },
+          });
+          return c.html(page('Incorrect password. Try again.'), 401);
+        }
+        codeAuthMethod = 'Password';
+      }
+    }
+
     // Hosted AuthKit asks which organization here, before it mints anything, so the client's
     // exchange always succeeds. Resolving it at the exchange instead would answer a browser
     // client with organization_selection_required, which it cannot act on mid-callback.
     // Interactive only: a headless caller drives the documented API and handles that response
     // itself, and this is the one mode that can put a page in front of a human.
-    if (!organizationId && store.getData<boolean>(STORE_KEYS.interactiveAuth)) {
+    if (!organizationId && interactive) {
       const selectable = activeOrganizationsFor(user.id);
       if (selectable.length > 1) {
-        const hiddenFields: Record<string, string> = { redirect_uri: redirectUri, email: user.email };
-        if (state) hiddenFields.state = state;
-        if (codeChallenge) hiddenFields.code_challenge = codeChallenge;
-        if (codeChallengeMethod) hiddenFields.code_challenge_method = codeChallengeMethod;
-        if (clientId) hiddenFields.client_id = clientId;
+        const hiddenFields: Record<string, string> = { ...carriedFields(params), email: user.email };
+        if (codeAuthMethod) {
+          // Reuse the token that got here when there is one; otherwise this is the first page
+          // after the password, and the check it just passed is what the token records.
+          let token = verifiedLoginKey ? pendingToken : null;
+          if (!token) {
+            token = generateId('pending');
+            const login: InteractiveLogin = {
+              user_id: user.id,
+              auth_method: codeAuthMethod,
+              expires_at: expiresIn(10),
+            };
+            store.setData(`${STORE_KEY_PREFIXES.interactiveLogin}${token}`, login);
+          }
+          hiddenFields.pending_authentication_token = token;
+        }
 
         return c.html(
           renderOrganizationSelectPage({
@@ -158,7 +269,10 @@ export function authRoutes(ctx: RouteContext): void {
       code_challenge: codeChallenge ?? null,
       code_challenge_method: codeChallengeMethod ?? null,
       client_id: clientId,
+      auth_method: codeAuthMethod,
     });
+    // One code per verified login: the token is spent once it has minted something.
+    if (verifiedLoginKey) store.setData(verifiedLoginKey, undefined);
 
     const redirect = new URL(redirectUri);
     redirect.searchParams.set('code', authCode.code);
@@ -219,6 +333,8 @@ export function authRoutes(ctx: RouteContext): void {
       loginHint,
       clientId,
       organizationId,
+      password: null,
+      pendingToken: null,
     });
   });
 
@@ -237,6 +353,9 @@ export function authRoutes(ctx: RouteContext): void {
       loginHint: (form.email as string) ?? null,
       clientId: (form.client_id as string) ?? null,
       organizationId: (form.organization_id as string) ?? null,
+      // A string, even an empty one, is an attempt; absent means the form has not asked yet.
+      password: typeof form.password === 'string' ? form.password : null,
+      pendingToken: (form.pending_authentication_token as string) ?? null,
     });
   });
 
@@ -629,7 +748,9 @@ export function authRoutes(ctx: RouteContext): void {
         // redemption-time request parameter.
         grantClientId = authCode.client_id ?? undefined;
         ws.authCodes.delete(authCode.id);
-        authMethod = 'OAuth';
+        // The interactive password page records how it verified the user; the auto-redirect
+        // verifies nothing and leaves this null, so the grant stays the OAuth it always was.
+        authMethod = authCode.auth_method ?? 'OAuth';
         break;
       }
 

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -18,7 +18,6 @@ import {
   isExpired,
   expiresIn,
   assertAllowedRedirectUri,
-  sealSession,
   AUTH_METHOD_SESSION_VALUES,
   resolveResponseAuthMethod,
   resolveSessionResponseAuthMethod,
@@ -290,7 +289,6 @@ export function authRoutes(ctx: RouteContext): void {
     const body = await parseOAuthBody(c);
     const grantType = body.grant_type as string | undefined;
     const clientId = body.client_id as string | undefined;
-    const clientSecret = body.client_secret as string | undefined;
 
     // Every malformed-request failure on this endpoint is OAuth-shaped, and not by inference:
     // the spec's authenticate 400 lists `invalid_request` among its {error, error_description}
@@ -1150,19 +1148,6 @@ export function authRoutes(ctx: RouteContext): void {
       client_id: tokenClientId ?? null,
     });
 
-    // Compute sealed session when client_secret is provided
-    const apiKey = c.req
-      .header('Authorization')
-      ?.replace(/^Bearer\s+/i, '')
-      .trim();
-    const sealKey = clientSecret ?? apiKey;
-    const sealedSession = sealKey
-      ? sealSession(
-          { access_token: accessToken, refresh_token: newRefreshToken.token, session_id: session.id },
-          sealKey,
-        )
-      : null;
-
     // Emit authentication event (hybrid Option B for action-specific events)
     if (isFreshLogin) {
       emitAuthenticationEvent({
@@ -1196,7 +1181,10 @@ export function authRoutes(ctx: RouteContext): void {
         : resolveSessionResponseAuthMethod(session.auth_method, {
             oauthProvider: updatedUser.oauth_provider,
           }),
-      sealed_session: sealedSession,
+      // Production never returns sealed_session for API requests: the SDKs seal client-side
+      // with a caller-supplied cookie password the server never sees. A non-null value here
+      // pushes authkit-nextjs session cookies past the 4096-byte browser cap (issue #93).
+      sealed_session: null,
       impersonator: updatedUser.impersonator ?? undefined,
     });
   };

--- a/src/workos/routes/auth.ts
+++ b/src/workos/routes/auth.ts
@@ -183,8 +183,13 @@ export function authRoutes(ctx: RouteContext): void {
     let verifiedLoginKey: string | null = null;
     if (interactive && store.getData<boolean>(STORE_KEYS.interactivePassword) && user.password_hash) {
       const key = pendingToken ? `${STORE_KEY_PREFIXES.interactiveLogin}${pendingToken}` : null;
-      const verified = key ? store.getData<InteractiveLogin>(key) : undefined;
-      if (verified && verified.user_id === user.id && !isExpired(verified.expires_at)) {
+      let verified = key ? store.getData<InteractiveLogin>(key) : undefined;
+      if (key && verified && isExpired(verified.expires_at)) {
+        // Nothing will ever redeem an expired token, so drop it rather than leave it behind.
+        store.deleteData(key);
+        verified = undefined;
+      }
+      if (verified && verified.user_id === user.id) {
         codeAuthMethod = verified.auth_method;
         verifiedLoginKey = key;
       } else {
@@ -271,8 +276,9 @@ export function authRoutes(ctx: RouteContext): void {
       client_id: clientId,
       auth_method: codeAuthMethod,
     });
-    // One code per verified login: the token is spent once it has minted something.
-    if (verifiedLoginKey) store.setData(verifiedLoginKey, undefined);
+    // One code per verified login: the token is spent once it has minted something. Deleted
+    // rather than overwritten, so a long-lived emulator does not keep one entry per login.
+    if (verifiedLoginKey) store.deleteData(verifiedLoginKey);
 
     const redirect = new URL(redirectUri);
     redirect.searchParams.set('code', authCode.code);


### PR DESCRIPTION
## Summary

- **`--interactive-password` / `interactiveAuth: { password: true }`** adds the step hosted AuthKit puts after the email: a user who has a password gets a password page before any organization selection. The interactive page was email-only, so a Playwright suite written against hosted AuthKit had no password field to fill and no wrong-password path to assert. Opt-in, because the one-step email page is what every existing interactive suite was written against; plain `--interactive` is unchanged.
- **A wrong password** re-renders the page with an inline error (HTTP 401) and emits `authentication.password_failed` with `invalid_credentials`, the same event the `password` grant emits. Nothing reaches the callback until the password is right.
- **The auth code records the method**, so the exchange emits `authentication.password_succeeded` and returns `"authentication_method": "Password"` instead of claiming OAuth for a login it verified with a password.
- **The organization page carries a short-lived token, not the password.** A verified login is remembered server-side for ten minutes and spent when it mints a code. Posting an `organization_id` without that token lands back on the password page, so the check cannot be skipped.
- **`sealed_session` is now always `null`** from `/user_management/authenticate`. Production never seals on the server; the SDKs seal client-side with a cookie password the API never sees. The emulator's own sealing pushed authkit-nextjs session cookies past the 4096-byte browser cap. Fixes #93.

Also ignores the local Dolt database and credential key that `bd init` writes.

## Usage

```bash
workos-emulate --interactive-password --seed workos-emulate.config.yaml
```

```ts
await page.fill('input[name="email"]', 'alice@example.com');
await page.click('button[type="submit"]');
await page.fill('input[name="password"]', 'correct-horse');
await page.click('button[type="submit"]');
```

A user without a password skips the page. MFA challenges and the email-verification gate are not part of it. The README gains a "Requiring a password" section under Interactive Auth.
