### PR TITLE
fix(users): match duplicate email creation contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/bun": "^1.3.14",
         "@types/node": "~22.19.7",
         "@types/semver": "^7.7.1",
+        "@workos-inc/node": "10.8.0",
         "@workos/openapi-spec": "^0.80.0",
         "husky": "^9.1.7",
         "oxfmt": "^0.62.0",
@@ -147,6 +148,8 @@
     "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@workos-inc/node": ["@workos-inc/node@10.8.0", "", {}, "sha512-BmKwxaouV4hYhoJ9K0UPLC9LTpVfvnayvAy3lG9ELbZBoEWeaKkXoYn4W+d3vK7SZQ4qj/8PE7ve7sUKXnpRDA=="],
 
     "@workos/openapi-spec": ["@workos/openapi-spec@0.80.0", "", {}, "sha512-jMAJVVvnWEdT3cq8G8H7U7gWJ3gIC19gRmkxB7DEA7YU2NXbhfGOt2Z4GDtspgljRt/GAp/pPT2+B5oaLIUyjw=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/bun": "^1.3.14",
     "@types/node": "~22.19.7",
     "@types/semver": "^7.7.1",
+    "@workos-inc/node": "10.8.0",
     "@workos/openapi-spec": "^0.80.0",
     "husky": "^9.1.7",
     "oxfmt": "^0.62.0",

--- a/src/core/middleware/error-handler.ts
+++ b/src/core/middleware/error-handler.ts
@@ -6,7 +6,7 @@ export class WorkOSApiError extends Error {
     public status: number,
     message: string,
     public code: string,
-    public errors?: Array<{ field: string; code: string; message?: string }>,
+    public errors?: Array<{ field?: string; code: string; message?: string }>,
   ) {
     super(message);
     this.name = 'WorkOSApiError';

--- a/src/workos/routes/users.spec.ts
+++ b/src/workos/routes/users.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
+import { BadRequestException, WorkOS } from '@workos-inc/node';
 import { createServer, type ApiKeyMap } from '../../core/index.js';
 import { workosPlugin } from '../index.js';
 
@@ -83,8 +84,11 @@ describe('User routes', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'user@x.test' }),
     });
-    expect(second.status).toBe(409);
-    expect((await json(second)).code).toBe('user_already_exists');
+    expect(second.status).toBe(400);
+    expect(await json(second)).toMatchObject({
+      code: 'user_creation_error',
+      errors: [{ code: 'email_not_available' }],
+    });
   });
 
   // This is the lookup an SDK's listUsers({ email }) maps to, so it is how a caller finds the
@@ -106,17 +110,70 @@ describe('User routes', () => {
     expect(miss.data).toHaveLength(0);
   });
 
-  it('rejects duplicate email', async () => {
-    await req('/user_management/users', {
-      method: 'POST',
-      body: JSON.stringify({ email: 'dup@test.com' }),
-    });
+  it('matches the user-creation contract for a duplicate email without changing the existing user', async () => {
+    const created = await json(
+      await req('/user_management/users', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: 'dup@test.com',
+          first_name: 'Original',
+          last_name: 'User',
+          password: 'pass123',
+        }),
+      }),
+    );
     const res = await req('/user_management/users', {
       method: 'POST',
-      body: JSON.stringify({ email: 'dup@test.com' }),
+      body: JSON.stringify({
+        email: 'dup@test.com',
+        first_name: 'Changed',
+        last_name: 'User',
+        email_verified: true,
+        external_id: 'dup@test.com',
+      }),
     });
-    expect(res.status).toBe(409);
-    expect((await json(res)).code).toBe('user_already_exists');
+    expect(res.status).toBe(400);
+    expect(await json(res)).toEqual({
+      message: 'Could not create user.',
+      code: 'user_creation_error',
+      errors: [{ code: 'email_not_available', message: 'This email is not available.' }],
+    });
+
+    const unchanged = await json(await req(`/user_management/users/${created.id}`));
+    expect(unchanged).toMatchObject({
+      id: created.id,
+      email: 'dup@test.com',
+      first_name: 'Original',
+      last_name: 'User',
+      email_verified: false,
+      external_id: null,
+    });
+  });
+
+  it('is decoded as BadRequestException by @workos-inc/node', async () => {
+    const workos = new WorkOS({
+      apiKey: 'sk_test_users',
+      apiHostname: 'emulate.test',
+      https: false,
+      maxRetries: 0,
+      fetchFn: (async () =>
+        new Response(
+          JSON.stringify({
+            message: 'Could not create user.',
+            code: 'user_creation_error',
+            errors: [{ code: 'email_not_available', message: 'This email is not available.' }],
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        )) as unknown as typeof fetch,
+    });
+
+    await expect(workos.userManagement.createUser({ email: 'dup@test.com' })).rejects.toMatchObject({
+      name: BadRequestException.name,
+      status: 400,
+      message: 'Could not create user.',
+      code: 'user_creation_error',
+      errors: [{ code: 'email_not_available', message: 'This email is not available.' }],
+    });
   });
 
   it('gets user by id', async () => {

--- a/src/workos/routes/users.spec.ts
+++ b/src/workos/routes/users.spec.ts
@@ -151,28 +151,56 @@ describe('User routes', () => {
   });
 
   it('is decoded as BadRequestException by @workos-inc/node', async () => {
+    const fetchFn: typeof fetch = Object.assign(
+      async (...args: Parameters<typeof fetch>) => {
+        const [input, init] = args;
+        const request = input instanceof Request ? new Request(input, init) : new Request(input.toString(), init);
+        return await app.request(request);
+      },
+      { preconnect: fetch.preconnect },
+    );
     const workos = new WorkOS({
       apiKey: 'sk_test_users',
       apiHostname: 'emulate.test',
       https: false,
       maxRetries: 0,
-      fetchFn: (async () =>
-        new Response(
-          JSON.stringify({
-            message: 'Could not create user.',
-            code: 'user_creation_error',
-            errors: [{ code: 'email_not_available', message: 'This email is not available.' }],
-          }),
-          { status: 400, headers: { 'Content-Type': 'application/json' } },
-        )) as unknown as typeof fetch,
+      fetchFn,
     });
 
-    await expect(workos.userManagement.createUser({ email: 'dup@test.com' })).rejects.toMatchObject({
-      name: BadRequestException.name,
-      status: 400,
-      message: 'Could not create user.',
-      code: 'user_creation_error',
-      errors: [{ code: 'email_not_available', message: 'This email is not available.' }],
+    const created = await workos.userManagement.createUser({
+      email: 'sdk-dup@test.com',
+      firstName: 'Original',
+      lastName: 'User',
+      password: 'pass123',
+    });
+
+    try {
+      await workos.userManagement.createUser({
+        email: 'sdk-dup@test.com',
+        firstName: 'Changed',
+        lastName: 'User',
+        emailVerified: true,
+        externalId: 'sdk-dup@test.com',
+      });
+      throw new Error('Expected duplicate user creation to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(error).toMatchObject({
+        status: 400,
+        message: 'Could not create user.',
+        code: 'user_creation_error',
+        errors: [{ code: 'email_not_available', message: 'This email is not available.' }],
+      });
+    }
+
+    const unchanged = await workos.userManagement.getUser(created.id);
+    expect(unchanged).toMatchObject({
+      id: created.id,
+      email: 'sdk-dup@test.com',
+      firstName: 'Original',
+      lastName: 'User',
+      emailVerified: false,
+      externalId: null,
     });
   });
 

--- a/src/workos/routes/users.ts
+++ b/src/workos/routes/users.ts
@@ -38,7 +38,12 @@ export function userRoutes(ctx: RouteContext): void {
     // the ambiguity by insertion order.
     const existing = findUserByEmail(ws, email);
     if (existing) {
-      throw new WorkOSApiError(409, 'A user with this email already exists', 'user_already_exists');
+      // Production treats a taken email on this creation endpoint as a request failure, not a
+      // generic conflict. Keep this specific to user creation: other 409 contracts remain
+      // independently meaningful to their SDK callers.
+      throw new WorkOSApiError(400, 'Could not create user.', 'user_creation_error', [
+        { code: 'email_not_available', message: 'This email is not available.' },
+      ]);
     }
 
     if (body.name !== undefined && body.name !== null && typeof body.name !== 'string') {


### PR DESCRIPTION
## Summary
I noticed this while doing Integration Tests with Live WorkOS:


Align duplicate-email failures from POST /user_management/users with the expected WorkOS API contract.

- Return HTTP 400 with user_creation_error and the email_not_available error detail when the submitted email already exists.
- Preserve the existing user unchanged after the rejected creation.
- Add HTTP-contract coverage plus an @workos-inc/node 10.8.0 regression test that routes SDK requests through the in-memory emulator and verifies BadRequestException.

## Reproduction

1. Locally create a user with a unique valid email, first name, last name, and password.
2. Create another user with the same email plus email_verified: true and external_id.
3. Before this change, the emulator returned 409 user_already_exists.
4. With this change, it returns message Could not create user., code user_creation_error, and errors containing code email_not_available with message This email is not available.

The original user remains present and unchanged.

## Contract basis

This change implements the observed WorkOS API behavior for a duplicate email on user creation. The expected response is HTTP 400 with user_creation_error and an email_not_available detail, which @workos-inc/node 10.8.0 maps to BadRequestException.